### PR TITLE
clean up handling of no-op nick changes

### DIFF
--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -232,9 +232,6 @@ func (clients *ClientManager) SetNick(client *Client, session *Session, newNick 
 		// successful reattach!
 		return newNick, nil, back
 	} else if currentClient == client && currentClient.Nick() == newNick {
-		// see #1019: normally no-op nick changes are caught earlier, by performNickChange,
-		// but they are not detected there when force-guest-format is enabled (because
-		// the proposed nickname is e.g. alice and the current nickname is Guest-alice)
 		return "", errNoop, false
 	}
 	// analogous checks for skeletons

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -30,9 +30,6 @@ var (
 func performNickChange(server *Server, client *Client, target *Client, session *Session, nickname string, rb *ResponseBuffer) error {
 	currentNick := client.Nick()
 	details := target.Details()
-	if details.nick == nickname {
-		return nil
-	}
 	hadNick := details.nick != "*"
 	origNickMask := details.nickMask
 


### PR DESCRIPTION
This bug has some, shall we say, interesting consequences. But as far as I can tell, there are no serious security implications. So I'm going to go ahead with releasing master as 2.3.0, going through the usual release candidate process.