### PR TITLE
fix znc.in/playback for individual DM targets

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -747,7 +747,7 @@ func (client *Client) playReattachMessages(session *Session) {
 	}
 	if !session.autoreplayMissedSince.IsZero() && !hasHistoryCaps {
 		rb := NewResponseBuffer(session)
-		zncPlayPrivmsgs(client, rb, "", time.Now().UTC(), session.autoreplayMissedSince)
+		zncPlayPrivmsgsFromAll(client, rb, time.Now().UTC(), session.autoreplayMissedSince)
 		rb.Send(true)
 	}
 	session.autoreplayMissedSince = time.Time{}


### PR DESCRIPTION
This is a regression introduced in 0d05ab4ff4249f (so it doesn't get a changelog entry).

Thanks @mikaela and @kylef for finding this!