### PR TITLE
Show email in NS INFO when user has permission.

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1259,6 +1259,9 @@ func (am *AccountManager) deserializeRawAccount(raw rawClientAccount, cfName str
 		return
 	}
 	result.AdditionalNicks = unmarshalReservedNicks(raw.AdditionalNicks)
+	if strings.HasPrefix(raw.Callback, "mailto:") {
+		result.Email = strings.TrimPrefix(raw.Callback, "mailto:")
+	}
 	result.Verified = raw.Verified
 	if raw.VHost != "" {
 		e := json.Unmarshal([]byte(raw.VHost), &result.VHost)
@@ -2032,6 +2035,7 @@ type ClientAccount struct {
 	Name            string
 	NameCasefolded  string
 	RegisteredAt    time.Time
+	Email           string
 	Credentials     AccountCredentials
 	Verified        bool
 	Suspended       *AccountSuspension

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -813,6 +813,13 @@ func nsInfoHandler(service *ircService, server *Server, client *Client, command 
 	service.Notice(rb, fmt.Sprintf(client.t("Account: %s"), account.Name))
 	registeredAt := account.RegisteredAt.Format(time.RFC1123)
 	service.Notice(rb, fmt.Sprintf(client.t("Registered at: %s"), registeredAt))
+
+	if account.Name == client.AccountName() || client.HasRoleCapabs("accreg") {
+		if account.Email != "" {
+			service.Notice(rb, fmt.Sprintf(client.t("Email address: %s"), account.Email))
+		}
+	}
+
 	// TODO nicer formatting for this
 	for _, nick := range account.AdditionalNicks {
 		service.Notice(rb, fmt.Sprintf(client.t("Additional grouped nick: %s"), nick))


### PR DESCRIPTION
Users logged into an account can see their own email.
Opers with the accreg capability can see all users.