### PR TITLE
update ChanServ OP command documentation

### DIFF
--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -29,7 +29,7 @@ var (
 			help: `Syntax: $bOP #channel [nickname]$b
 
 OP makes the given nickname, or yourself, a channel admin. You can only use
-this command if you're the founder of the channel.`,
+this command if you're a founder or in the AMODEs of the channel.`,
 			helpShort:    `$bOP$b makes the given user (or yourself) a channel admin.`,
 			authRequired: true,
 			enabled:      chanregEnabled,


### PR DESCRIPTION
Commit 7ce396931cff32558112c65e1f9c93aacc5c7a1f introduced the ability
that every user with an account in the AMODE list of a channel can use
the OP command to restore their modes. Update the chanserv help message
accordingly.