### PR TITLE
fix #1703

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3422,9 +3422,6 @@ func whowasHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 	//}
 	cnick := client.Nick()
 	for _, nickname := range nicknames {
-		if len(nickname) == 0 {
-			continue
-		}
 		results := server.whoWas.Find(nickname, count)
 		if len(results) == 0 {
 			rb.Add(nil, server.name, ERR_WASNOSUCHNICK, cnick, utils.SafeErrorParam(nickname), client.t("There was no such nickname"))


### PR DESCRIPTION
`WHOWAS :` should return an error numeric instead of an empty response