### PR TITLE
Session Disconnect SNO

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -1227,7 +1227,9 @@ func (client *Client) destroy(session *Session) {
 	} else {
 		sessionRemoved, remainingSessions = client.removeSession(session)
 		if sessionRemoved {
-			client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprint(ircfmt.Unescape("Client session disconnected for [%s] [h:%s] [ip:%s]$r"), client.accountName, session.rawHostname, session.realIP))
+			if alwaysOn || remainingSessions > 0 {
+				client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprintf(ircfmt.Unescape("Client session disconnected for [a:%s] [h:%s] [ip:%s]"), details.accountName, session.rawHostname, session.IP().String()))
+			}
 			sessionsToDestroy = []*Session{session}
 		}
 	}

--- a/irc/client.go
+++ b/irc/client.go
@@ -1227,6 +1227,7 @@ func (client *Client) destroy(session *Session) {
 	} else {
 		sessionRemoved, remainingSessions = client.removeSession(session)
 		if sessionRemoved {
+			client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprint(ircfmt.Unescape("Client session disconnected for [%s] [h:%s] [ip:%s]$r"), client.accountName, session.rawHostname, session.realIP))
 			sessionsToDestroy = []*Session{session}
 		}
 	}

--- a/irc/sno/constants.go
+++ b/irc/sno/constants.go
@@ -13,6 +13,7 @@ type Masks []Mask
 const (
 	LocalAnnouncements Mask = 'a'
 	LocalConnects      Mask = 'c'
+	LocalDisconnects   Mask = 'd'
 	LocalChannels      Mask = 'j'
 	LocalKills         Mask = 'k'
 	LocalNicks         Mask = 'n'
@@ -29,6 +30,7 @@ var (
 	NoticeMaskNames = map[Mask]string{
 		LocalAnnouncements: "ANNOUNCEMENT",
 		LocalConnects:      "CONNECT",
+		LocalDisconnects:   "DISCONNECT",
 		LocalChannels:      "CHANNEL",
 		LocalKills:         "KILL",
 		LocalNicks:         "NICK",
@@ -44,6 +46,7 @@ var (
 	ValidMasks = []Mask{
 		LocalAnnouncements,
 		LocalConnects,
+		LocalDisconnects,
 		LocalChannels,
 		LocalKills,
 		LocalNicks,


### PR DESCRIPTION
```
10:26 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FOPER\x0314-\x03 Client opered up \x0314[\x0Fmogad0n1!~u@staff\x0314, \x0Fadmin\x0314]
10:26 --> test :ergo.test 381 mogad0n1 :You are now an IRC operator
10:26 --> test :ergo.test MODE mogad0n1 +os +acdjknoqtuxv
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [mogad0n] [u:~u] [h:127.0.0.1] [ip:127.0.0.1] [r:mogad0n]
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fmogad0n!~u@9673wdh7fyncw.irc\x0314] logged into account \x0314[\x0Fmogad0n\x0314]
10:27 <-- test PING localhost
10:27 --> test :ergo.test PONG ergo.test localhost
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [NoSir] [u:~u] [h:0::1] [ip:::1] [r:we]
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FQUIT\x0314-\x03 NoSir\x0F exited the network
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FDISCONNECT\x0314-\x03 Client session disconnected for [a:mogad0n] [h:0::1] [ip:::1]\x0F
10:28 <-- test PING localhost
10:28 --> test :ergo.test PONG ergo.test localhost
10:29 <-- test PING localhost
10:29 --> test :ergo.test PONG ergo.test localhost
10:29 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FQUIT\x0314-\x03 mogad0n\x0F exited the network
10:29 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [mogad0n] [u:~u] [h:0::1] [ip:::1] [r:mogad0n]
10:29 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fmogad0n!~u@9673wdh7fyncw.irc\x0314] logged into account \x0314[\x0Fmogad0n\x0314]
10:30 <-- test PING localhost
10:30 --> test :ergo.test PONG ergo.test localhost
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [mogad0n] [u:~u] [h:127.0.0.1] [ip:127.0.0.1] [r:mogad0n]
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fmogad0n!~u@9673wdh7fyncw.irc\x0314] logged into account \x0314[\x0Fmogad0n\x0314]
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FDISCONNECT\x0314-\x03 Client session disconnected for [a:mogad0n] [h:0::1] [ip:::1]\x0F
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FQUIT\x0314-\x03 mogad0n\x0F exited the network
```
Raw logs.
1. Nick: NoSir is an unregistered user and their disconnect sends the usual quit.
2. Nick: mogad0n is registered. Two tests were performed:
   i. always-on enabled: Disconnecting the session resulted in the `-DISCONNECT-` `NOTICE` (the 'a' in `[a:<account>]`  stands for accountname) it's probably not a great idea but imo it's good for that rare situation where someone has `force-nick-equals-account: false`
   ii. always-on disabled: Disconnecting first session sends the same `-DISCONNECT-` but if you disconnect your final "multiclient-session" then it doesn't send that and sends `-QUIT-` which seems to have been the way it usually works.
   
#1644 