### PR TITLE
Implementing SNO for session disconnect (in bouncer modes)

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -654,7 +654,7 @@ opers:
         # modes are modes to auto-set upon opering-up. uncomment this to automatically
         # enable snomasks ("server notification masks" that alert you to server events;
         # see `/quote help snomasks` while opered-up for more information):
-        #modes: +is acjknoqtuxv
+        #modes: +is acdjknoqtuxv
 
         # operators can be authenticated either by password (with the /OPER command),
         # or by certificate fingerprint, or both. if a password hash is set, then a

--- a/irc/client.go
+++ b/irc/client.go
@@ -1227,6 +1227,9 @@ func (client *Client) destroy(session *Session) {
 	} else {
 		sessionRemoved, remainingSessions = client.removeSession(session)
 		if sessionRemoved {
+			if alwaysOn || remainingSessions > 0 {
+				client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprintf(ircfmt.Unescape("Client session disconnected for [a:%s] [h:%s] [ip:%s]"), details.accountName, session.rawHostname, session.IP().String()))
+			}
 			sessionsToDestroy = []*Session{session}
 		}
 	}

--- a/irc/help.go
+++ b/irc/help.go
@@ -87,6 +87,7 @@ Ergo supports the following server notice masks for operators:
 
   a  |  Local announcements.
   c  |  Local client connections.
+  d  |  Local session disconnects.
   j  |  Local channel actions.
   k  |  Local kills.
   n  |  Local nick changes.

--- a/irc/sno/constants.go
+++ b/irc/sno/constants.go
@@ -13,6 +13,7 @@ type Masks []Mask
 const (
 	LocalAnnouncements Mask = 'a'
 	LocalConnects      Mask = 'c'
+	LocalDisconnects   Mask = 'd'
 	LocalChannels      Mask = 'j'
 	LocalKills         Mask = 'k'
 	LocalNicks         Mask = 'n'
@@ -29,6 +30,7 @@ var (
 	NoticeMaskNames = map[Mask]string{
 		LocalAnnouncements: "ANNOUNCEMENT",
 		LocalConnects:      "CONNECT",
+		LocalDisconnects:   "DISCONNECT",
 		LocalChannels:      "CHANNEL",
 		LocalKills:         "KILL",
 		LocalNicks:         "NICK",
@@ -44,6 +46,7 @@ var (
 	ValidMasks = []Mask{
 		LocalAnnouncements,
 		LocalConnects,
+		LocalDisconnects,
 		LocalChannels,
 		LocalKills,
 		LocalNicks,

--- a/irc/sno/utils_test.go
+++ b/irc/sno/utils_test.go
@@ -17,14 +17,14 @@ func assertEqual(supplied, expected interface{}, t *testing.T) {
 
 func TestEvaluateSnomaskChanges(t *testing.T) {
 	add, remove, newArg := EvaluateSnomaskChanges(true, "*", nil)
-	assertEqual(add, Masks{'a', 'c', 'j', 'k', 'n', 'o', 'q', 't', 'u', 'v', 'x'}, t)
+	assertEqual(add, Masks{'a', 'c', 'd', 'j', 'k', 'n', 'o', 'q', 't', 'u', 'v', 'x'}, t)
 	assertEqual(len(remove), 0, t)
-	assertEqual(newArg, "+acjknoqtuvx", t)
+	assertEqual(newArg, "+acdjknoqtuvx", t)
 
 	add, remove, newArg = EvaluateSnomaskChanges(true, "*", Masks{'a', 'u'})
-	assertEqual(add, Masks{'c', 'j', 'k', 'n', 'o', 'q', 't', 'v', 'x'}, t)
+	assertEqual(add, Masks{'c', 'd', 'j', 'k', 'n', 'o', 'q', 't', 'v', 'x'}, t)
 	assertEqual(len(remove), 0, t)
-	assertEqual(newArg, "+cjknoqtvx", t)
+	assertEqual(newArg, "+cdjknoqtvx", t)
 
 	add, remove, newArg = EvaluateSnomaskChanges(true, "-a", Masks{'a', 'u'})
 	assertEqual(len(add), 0, t)


### PR DESCRIPTION
```
10:26 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FOPER\x0314-\x03 Client opered up \x0314[\x0Fmogad0n1!~u@staff\x0314, \x0Fadmin\x0314]
10:26 --> test :ergo.test 381 mogad0n1 :You are now an IRC operator
10:26 --> test :ergo.test MODE mogad0n1 +os +acdjknoqtuxv
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [mogad0n] [u:~u] [h:127.0.0.1] [ip:127.0.0.1] [r:mogad0n]
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fmogad0n!~u@9673wdh7fyncw.irc\x0314] logged into account \x0314[\x0Fmogad0n\x0314]
10:27 <-- test PING localhost
10:27 --> test :ergo.test PONG ergo.test localhost
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [NoSir] [u:~u] [h:0::1] [ip:::1] [r:we]
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FQUIT\x0314-\x03 NoSir\x0F exited the network
10:27 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FDISCONNECT\x0314-\x03 Client session disconnected for [a:mogad0n] [h:0::1] [ip:::1]\x0F
10:28 <-- test PING localhost
10:28 --> test :ergo.test PONG ergo.test localhost
10:29 <-- test PING localhost
10:29 --> test :ergo.test PONG ergo.test localhost
10:29 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FQUIT\x0314-\x03 mogad0n\x0F exited the network
10:29 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [mogad0n] [u:~u] [h:0::1] [ip:::1] [r:mogad0n]
10:29 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fmogad0n!~u@9673wdh7fyncw.irc\x0314] logged into account \x0314[\x0Fmogad0n\x0314]
10:30 <-- test PING localhost
10:30 --> test :ergo.test PONG ergo.test localhost
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FCONNECT\x0314-\x03 Client connected [mogad0n] [u:~u] [h:127.0.0.1] [ip:127.0.0.1] [r:mogad0n]
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fmogad0n!~u@9673wdh7fyncw.irc\x0314] logged into account \x0314[\x0Fmogad0n\x0314]
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FDISCONNECT\x0314-\x03 Client session disconnected for [a:mogad0n] [h:0::1] [ip:::1]\x0F
10:30 --> test :ergo.test NOTICE mogad0n1 :\x0314-\x0FQUIT\x0314-\x03 mogad0n\x0F exited the network
```
Raw logs.
1. Nick: NoSir is an unregistered user and their disconnect sends the usual quit.
2. Nick: mogad0n is registered. Two tests were performed:
   i. always-on enabled: Disconnecting the session resulted in the `-DISCONNECT-` `NOTICE` (the 'a' in `[a:<account>]`  stands for accountname) it's probably not a great idea but imo it's good for that rare situation where someone has `force-nick-equals-account: false`
   ii. always-on disabled: Disconnecting first session sends the same `-DISCONNECT-` but if you disconnect your final "multiclient-session" then it doesn't send that and sends `-QUIT-` which seems to have been the way it usually works.
   
#1644 

vscode asks me if i'd like to run tests;
```
Running tool: /usr/bin/go test -timeout 30s -run ^TestEvaluateSnomaskChanges$ github.com/ergochat/ergo/irc/sno

ok  	github.com/ergochat/ergo/irc/sno	0.001s
```