### PR TITLE
Fixing the AUR package link in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ergo run     # server should be ready to go!
 
 Some platforms/distros also have Ergo packages maintained for them:
 
-* Arch Linux [AUR](https://aur.archlinux.org/packages/oragono/) - Maintained by [Sean Enck (@enckse)](https://github.com/enckse).
+* Arch Linux [AUR](https://aur.archlinux.org/packages/ergochat/) - Maintained by [Jason Papakostas (@vith)](https://github.com/vith).
 
 ### Using Docker
 


### PR DESCRIPTION
The AUR (arch linux user repository) link in the README.md was pointing to the AUR with the old name and was throwning a 404 error message. 

This PR changes it to the the right AUR package https://aur.archlinux.org/packages/ergochat/