### PR TITLE
DISCONNECT SNO for always-on and/or multiclient

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -654,7 +654,7 @@ opers:
         # modes are modes to auto-set upon opering-up. uncomment this to automatically
         # enable snomasks ("server notification masks" that alert you to server events;
         # see `/quote help snomasks` while opered-up for more information):
-        #modes: +is acjknoqtuxv
+        #modes: +is acdjknoqtuxv
 
         # operators can be authenticated either by password (with the /OPER command),
         # or by certificate fingerprint, or both. if a password hash is set, then a

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -815,7 +815,7 @@ If this mode is unset, users who aren't on your channel can send messages to it.
 
 If this mode is set, only users that have logged into an account will be able to join and speak on the channel. If this is set and a regular, un-logged-in user tries to join, they will be rejected.
 
-Unregistered users already joined to the channel will no longer be able to send messages to it, but they will not be kicked automatically. If they leave, they would not be allowed to rejoin.
+Unregistered users already joined to the channel will not be kicked automatically. They will no longer be able to send messages to the channel, unless they have been voiced (+v). If they leave, they would not be allowed to rejoin.
 
 To set this mode:
 

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1231,7 +1231,8 @@ func (channel *Channel) CanSpeak(client *Client) (bool, modes.Mode) {
 	if channel.flags.HasMode(modes.Moderated) && clientModes.HighestChannelUserMode() == modes.Mode(0) {
 		return false, modes.Moderated
 	}
-	if channel.flags.HasMode(modes.RegisteredOnly) && client.Account() == "" {
+	if channel.flags.HasMode(modes.RegisteredOnly) && client.Account() == "" &&
+		clientModes.HighestChannelUserMode() == modes.Mode(0) {
 		return false, modes.RegisteredOnly
 	}
 	if channel.flags.HasMode(modes.RegisteredOnlySpeak) && client.Account() == "" &&

--- a/irc/client.go
+++ b/irc/client.go
@@ -1310,6 +1310,9 @@ func (client *Client) destroy(session *Session) {
 			client.server.connectionLimiter.RemoveClient(flatip.FromNetIP(ip))
 			source = ip.String()
 		}
+		if !shouldDestroy {
+			client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprintf(ircfmt.Unescape("Client session disconnected for [a:%s] [h:%s] [ip:%s]"), details.accountName, session.rawHostname, session.IP().String()))
+		}
 		client.server.logger.Info("connect-ip", fmt.Sprintf("disconnecting session of %s from %s", details.nick, source))
 	}
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -1311,7 +1311,7 @@ func (client *Client) destroy(session *Session) {
 			source = ip.String()
 		}
 		if !shouldDestroy {
-			client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprintf(ircfmt.Unescape("Client session disconnected for [a:%s] [h:%s] [ip:%s]"), details.accountName, session.rawHostname, session.IP().String()))
+			client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprintf(ircfmt.Unescape("Client session disconnected for [a:%s] [h:%s] [ip:%s]"), details.accountName, session.rawHostname, source))
 		}
 		client.server.logger.Info("connect-ip", fmt.Sprintf("disconnecting session of %s from %s", details.nick, source))
 	}

--- a/irc/modes.go
+++ b/irc/modes.go
@@ -232,7 +232,7 @@ func (channel *Channel) ApplyChannelModeChanges(client *Client, isSamode bool, c
 				} else if err != nil {
 					rb.Add(nil, client.server.name, ERR_INVALIDMODEPARAM, details.nick, string(change.Mode), utils.SafeErrorParam(mask), fmt.Sprintf(client.t("Invalid mode %[1]s parameter: %[2]s"), string(change.Mode), mask))
 				} else {
-					rb.Add(nil, client.server.name, ERR_LISTMODEALREADYSET, chname, mask, string(change.Mode), fmt.Sprintf(client.t("Channel %[1]s list already contains %[2]s"), chname, mask))
+					rb.Add(nil, client.server.name, ERR_LISTMODEALREADYSET, details.nick, chname, mask, string(change.Mode), fmt.Sprintf(client.t("Channel %[1]s list already contains %[2]s"), chname, mask))
 				}
 
 			case modes.Remove:
@@ -244,7 +244,7 @@ func (channel *Channel) ApplyChannelModeChanges(client *Client, isSamode bool, c
 				} else if err != nil {
 					rb.Add(nil, client.server.name, ERR_INVALIDMODEPARAM, details.nick, string(change.Mode), utils.SafeErrorParam(mask), fmt.Sprintf(client.t("Invalid mode %[1]s parameter: %[2]s"), string(change.Mode), mask))
 				} else {
-					rb.Add(nil, client.server.name, ERR_LISTMODENOTSET, chname, mask, string(change.Mode), fmt.Sprintf(client.t("Channel %[1]s list does not contain %[2]s"), chname, mask))
+					rb.Add(nil, client.server.name, ERR_LISTMODENOTSET, details.nick, chname, mask, string(change.Mode), fmt.Sprintf(client.t("Channel %[1]s list does not contain %[2]s"), chname, mask))
 				}
 			}
 

--- a/irc/sno/constants.go
+++ b/irc/sno/constants.go
@@ -13,6 +13,7 @@ type Masks []Mask
 const (
 	LocalAnnouncements Mask = 'a'
 	LocalConnects      Mask = 'c'
+	LocalDisconnects   Mask = 'd'
 	LocalChannels      Mask = 'j'
 	LocalKills         Mask = 'k'
 	LocalNicks         Mask = 'n'
@@ -29,6 +30,7 @@ var (
 	NoticeMaskNames = map[Mask]string{
 		LocalAnnouncements: "ANNOUNCEMENT",
 		LocalConnects:      "CONNECT",
+		LocalDisconnects:   "DISCONNECT",
 		LocalChannels:      "CHANNEL",
 		LocalKills:         "KILL",
 		LocalNicks:         "NICK",
@@ -44,6 +46,7 @@ var (
 	ValidMasks = []Mask{
 		LocalAnnouncements,
 		LocalConnects,
+		LocalDisconnects,
 		LocalChannels,
 		LocalKills,
 		LocalNicks,

--- a/irc/sno/utils_test.go
+++ b/irc/sno/utils_test.go
@@ -17,14 +17,14 @@ func assertEqual(supplied, expected interface{}, t *testing.T) {
 
 func TestEvaluateSnomaskChanges(t *testing.T) {
 	add, remove, newArg := EvaluateSnomaskChanges(true, "*", nil)
-	assertEqual(add, Masks{'a', 'c', 'j', 'k', 'n', 'o', 'q', 't', 'u', 'v', 'x'}, t)
+	assertEqual(add, Masks{'a', 'c', 'd', 'j', 'k', 'n', 'o', 'q', 't', 'u', 'v', 'x'}, t)
 	assertEqual(len(remove), 0, t)
-	assertEqual(newArg, "+acjknoqtuvx", t)
+	assertEqual(newArg, "+acdjknoqtuvx", t)
 
 	add, remove, newArg = EvaluateSnomaskChanges(true, "*", Masks{'a', 'u'})
-	assertEqual(add, Masks{'c', 'j', 'k', 'n', 'o', 'q', 't', 'v', 'x'}, t)
+	assertEqual(add, Masks{'c', 'd', 'j', 'k', 'n', 'o', 'q', 't', 'v', 'x'}, t)
 	assertEqual(len(remove), 0, t)
-	assertEqual(newArg, "+cjknoqtvx", t)
+	assertEqual(newArg, "+cdjknoqtvx", t)
 
 	add, remove, newArg = EvaluateSnomaskChanges(true, "-a", Masks{'a', 'u'})
 	assertEqual(len(add), 0, t)

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -627,7 +627,7 @@ opers:
         # modes are modes to auto-set upon opering-up. uncomment this to automatically
         # enable snomasks ("server notification masks" that alert you to server events;
         # see `/quote help snomasks` while opered-up for more information):
-        #modes: +is acjknoqtuxv
+        #modes: +is acdjknoqtuxv
 
         # operators can be authenticated either by password (with the /OPER command),
         # or by certificate fingerprint, or both. if a password hash is set, then a


### PR DESCRIPTION
Works to solve #1709 

This should work with always-on expiring as intended too?

I have tested the following situations:
1. Unregistered Nick sends QUIT
2. Always-on without any other client sends only DISCONNECT
3. Always-on off but multiclient sends DISCONNECT if there is another session online. But sends QUIT on the last session.

I expect to have covered everything, the yamls, the `sno/constants.go` the `utils_check/test` and the clients.go has a small change.
I hope the format is acceptable `[a:<account>]`.