### PR TITLE
fix missing disconnect sno help text

### DIFF
--- a/irc/help.go
+++ b/irc/help.go
@@ -87,6 +87,7 @@ Ergo supports the following server notice masks for operators:
 
   a  |  Local announcements.
   c  |  Local client connections.
+  d  |  Local client disconnects.
   j  |  Local channel actions.
   k  |  Local kills.
   n  |  Local nick changes.


### PR DESCRIPTION
Forgot to add to the `snomaskHelpText` in `help.go`  when I had sent  #1728  