### PR TITLE
fix incorrect handling of overlong lines when allow-truncation is enabled

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -711,9 +711,11 @@ func (client *Client) run(session *Session) {
 		} else if err == ircmsg.ErrorTagsTooLong {
 			session.Send(nil, client.server.name, ERR_INPUTTOOLONG, client.Nick(), client.t("Input line contained excess tag data"))
 			continue
-		} else if err == ircmsg.ErrorBodyTooLong && !client.server.Config().Server.Compatibility.allowTruncation {
-			session.Send(nil, client.server.name, ERR_INPUTTOOLONG, client.Nick(), client.t("Input line too long"))
-			continue
+		} else if err == ircmsg.ErrorBodyTooLong {
+			if !client.server.Config().Server.Compatibility.allowTruncation {
+				session.Send(nil, client.server.name, ERR_INPUTTOOLONG, client.Nick(), client.t("Input line too long"))
+				continue
+			} // else: proceed with the truncated line
 		} else if err != nil {
 			client.Quit(client.t("Received malformed line"), session)
 			break


### PR DESCRIPTION
This is a bug in #1577 / 03185ea4a9547c8b. The intent was that if allow-truncation was enabled, lines over 512 bytes would be processed in their truncated form. Instead, they were being rejected and the client was being disconnected. (We were hitting the `else if err != nil` case at the bottom of the conditional.)