### PR TITLE
fix SCRAM not supporting client IDs

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -2008,6 +2008,11 @@ func (am *AccountManager) NewScramConversation() *scram.ServerConversation {
 }
 
 func (am *AccountManager) lookupSCRAMCreds(accountName string) (creds scram.StoredCredentials, err error) {
+	// strip client ID if present:
+	if strudelIndex := strings.IndexByte(accountName, '@'); strudelIndex != -1 {
+		accountName = accountName[:strudelIndex]
+	}
+
 	acct, err := am.LoadAccount(accountName)
 	if err != nil {
 		return


### PR DESCRIPTION
reported by @Mikaela

Successful transcript made with irctest:

```
1628006140.243 1: connects to server.
1628006140.243 1 -> S: CAP LS 302
1628006140.243 S -> 1: :ergo.test CAP * LS :account-notify account-tag away-notify batch cap-notify chghost draft/account-registration draft/channel-rename draft/chathistory draft/event-playback draft/languages=1,en draft/multiline=max-bytes=4096,max-lines=32 draft/relaymsg=/ echo-message extended-join invite-notify labeled-response message-tags multi-prefix oragono.io/nope sasl=PLAIN,EXTERNAL,SCRAM-SHA-256 server-time setname userhost-in-names znc.in/playback znc.in/self-message
1628006140.243 1 -> S: CAP REQ :sasl
1628006140.243 S -> 1: :ergo.test NOTICE * :*** Looking up your hostname...
1628006140.243 S -> 1: :ergo.test NOTICE * :*** Found your hostname
1628006140.243 S -> 1: :ergo.test CAP * ACK sasl
1628006140.243 1 -> S: AUTHENTICATE SCRAM-SHA-256
1628006140.243 S -> 1: :ergo.test AUTHENTICATE +
1628006140.244 1 -> S: AUTHENTICATE biwsbj1TY3JhbXRlc3RAd2VlY2hhdCxyPWlVQ2p0VzVQN2V1NHNaY093U2xwcHg5czQtckp4a2Fwa3FKX3pHeGZXNlU=
1628006140.244 S -> 1: :ergo.test AUTHENTICATE cj1pVUNqdFc1UDdldTRzWmNPd1NscHB4OXM0LXJKeGthcGtxSl96R3hmVzZVZnlhclNrU2VrODhGNnlFWEdqdjZKNkthdm5nc3MycU8scz1QVERDdUg1b2x6a1E3YU9PSGdiM3hRPT0saT00MDk2
1628006140.272 1 -> S: AUTHENTICATE Yz1iaXdzLHI9aVVDanRXNVA3ZXU0c1pjT3dTbHBweDlzNC1ySnhrYXBrcUpfekd4Zlc2VWZ5YXJTa1Nlazg4RjZ5RVhHanY2SjZLYXZuZ3NzMnFPLHA9REtOWE95SFB2THRNWXpBV1R0d0xNcFBKOFBTeEZzOStrQTJrb1BtV0haTT0=
1628006140.272 S -> 1: :ergo.test AUTHENTICATE dj1VZUhBTHdiUmRHK1Y1ZHVScEhZWWlWVGtIOXpYZEs5ZkRNQjJDd1BwcEdVPQ==
1628006140.272 1 -> S: AUTHENTICATE +
1628006140.272 S -> 1: :ergo.test 900 * * Scramtest :You are now logged in as Scramtest
1628006140.272 S -> 1: :ergo.test 903 * :Authentication successful
1628006140.280 1: disconnects from server.
```