### PR TITLE
Snos with deviceIDs

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -1315,8 +1315,16 @@ func (client *Client) destroy(session *Session) {
 			client.server.connectionLimiter.RemoveClient(flatip.FromNetIP(ip))
 			source = ip.String()
 		}
+		// generate disconn sno
+		var buf strings.Builder
+		fmt.Fprintf(&buf, "Client session disconnected for [a:%s]", details.accountName)
+		if session.deviceID != "" {
+			fmt.Fprintf(&buf, " [d:%s]", session.deviceID)
+		}
+		fmt.Fprintf(&buf, " [h:%s] [ip:%s]", session.rawHostname, source)
+		line := buf.String()
 		if !shouldDestroy {
-			client.server.snomasks.Send(sno.LocalDisconnects, fmt.Sprintf(ircfmt.Unescape("Client session disconnected for [a:%s] [h:%s] [ip:%s]"), details.accountName, session.rawHostname, source))
+			client.server.snomasks.Send(sno.LocalDisconnects, ircfmt.Unescape(line))
 		}
 		client.server.logger.Info("connect-ip", fmt.Sprintf("disconnecting session of %s from %s", details.nick, source))
 	}

--- a/irc/server.go
+++ b/irc/server.go
@@ -373,7 +373,14 @@ func (server *Server) playRegistrationBurst(session *Session) {
 	// continue registration
 	d := c.Details()
 	server.logger.Info("connect", fmt.Sprintf("Client connected [%s] [u:%s] [r:%s]", d.nick, d.username, d.realname))
-	server.snomasks.Send(sno.LocalConnects, fmt.Sprintf("Client connected [%s] [u:%s] [h:%s] [ip:%s] [r:%s]", d.nick, d.username, session.rawHostname, session.IP().String(), d.realname))
+	var buf strings.Builder
+	buf.WriteString("Client connected")
+	if session.deviceID != "" {
+		fmt.Fprintf(&buf, " from [d:%s]", session.deviceID)
+	}
+	fmt.Fprintf(&buf, " [%s] [u:%s] [h:%s] [ip:%s] [r:%s]", d.nick, d.username, session.rawHostname, session.IP().String(), d.realname)
+	line := buf.String()
+	server.snomasks.Send(sno.LocalConnects, ircfmt.Unescape(line))
 	if d.account != "" {
 		server.sendLoginSnomask(d.nickMask, d.accountName)
 	}


### PR DESCRIPTION
```
05:56 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FCONNECT\x0314-\x03 Client connected [nicknolte] [u:~u] [h:0::1] [ip:::1] [r:nicknolte]
05:56 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fnicknolte!~u@s3zbtep6y9jdy.irc\x0314] registered account \x0314[\x0Fnicknolte\x0314] from IP ::1
05:56 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fnicknolte!~u@s3zbtep6y9jdy.irc\x0314] logged into account \x0314[\x0Fnicknolte\x0314]
05:57 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FCONNECT\x0314-\x03 Client connected from [d:hex1] [nicknolte] [u:~u] [h:0::1] [ip:::1] [r:nicknolte]
05:57 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fnicknolte!~u@s3zbtep6y9jdy.irc\x0314] logged into account \x0314[\x0Fnicknolte\x0314]
05:58 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FDISCONNECT\x0314-\x03 Client session disconnected for [a:nicknolte] [h:0::1] [ip:::1]
05:58 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FCONNECT\x0314-\x03 Client connected from [d:hex2] [nicknolte] [u:~u] [h:0::1] [ip:::1] [r:nicknolte]
05:58 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FACCOUNT\x0314-\x03 Client \x0314[\x0Fnicknolte!~u@s3zbtep6y9jdy.irc\x0314] logged into account \x0314[\x0Fnicknolte\x0314]
05:58 --> local :ergo.test NOTICE mogad0n :\x0314-\x0FDISCONNECT\x0314-\x03 Client session disconnected for [a:nicknolte] [d:hex1] [h:0::1] [ip:::1]
```

I just got rid of `PING` messages. But that's how it looks. 