### PR TITLE
validateChannelKey: Reject empty keys

### DIFF
--- a/irc/modes.go
+++ b/irc/modes.go
@@ -148,9 +148,8 @@ func ParseDefaultUserModes(rawModes *string) modes.Modes {
 
 // #1021: channel key must be valid as a non-final parameter
 func validateChannelKey(key string) bool {
-	// empty string is valid in this context because it unsets the mode
 	if len(key) == 0 {
-		return true
+		return false
 	}
 	return key[0] != ':' && strings.IndexByte(key, ' ') == -1
 }


### PR DESCRIPTION
The value is actually '*' when unsetting the key; and '' should not
be allowed when adding.

matching irctest PR: https://github.com/ProgVal/irctest/pull/95