### PR TITLE
Make kick messages default to the kicker name instead of the kicked

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1373,6 +1373,9 @@ func kickHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 	if len(msg.Params) > 2 {
 		comment = msg.Params[2]
 	}
+	if comment == "" {
+		comment = client.Nick()
+	}
 	for _, kick := range kicks {
 		channel := server.channels.Get(kick.channel)
 		if channel == nil {
@@ -1384,10 +1387,6 @@ func kickHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 		if target == nil {
 			rb.Add(nil, server.name, ERR_NOSUCHNICK, client.nick, utils.SafeErrorParam(kick.nick), client.t("No such nick"))
 			continue
-		}
-
-		if comment == "" {
-			comment = kick.nick
 		}
 		channel.Kick(client, target, comment, rb, hasPrivs)
 	}


### PR DESCRIPTION
For consistency with RFC2812, Bahamut, Hybrid, Insp, Plexus4, Unreal.
https://datatracker.ietf.org/doc/html/rfc2812#section-3.2.8

At the expense of consistency with chary/solanum, irc2, and ircu2.

Will be tested by irctest: https://github.com/ProgVal/irctest/pull/100