### PR TITLE
Advertise support for multiple KICK targets

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -1588,7 +1588,7 @@ func (config *Config) generateISupport() (err error) {
 		isupport.Add("RPUSER", "E")
 	}
 	isupport.Add("STATUSMSG", "~&@%+")
-	isupport.Add("TARGMAX", fmt.Sprintf("NAMES:1,LIST:1,KICK:1,WHOIS:1,USERHOST:10,PRIVMSG:%s,TAGMSG:%s,NOTICE:%s,MONITOR:%d", maxTargetsString, maxTargetsString, maxTargetsString, config.Limits.MonitorEntries))
+	isupport.Add("TARGMAX", fmt.Sprintf("NAMES:1,LIST:1,KICK:,WHOIS:1,USERHOST:10,PRIVMSG:%s,TAGMSG:%s,NOTICE:%s,MONITOR:%d", maxTargetsString, maxTargetsString, maxTargetsString, config.Limits.MonitorEntries))
 	isupport.Add("TOPICLEN", strconv.Itoa(config.Limits.TopicLen))
 	if config.Server.Casemapping == CasemappingPRECIS {
 		isupport.Add("UTF8MAPPING", precisUTF8MappingToken)


### PR DESCRIPTION
This is already implemented, but TARGMAX=KICK:1 says it isn't.

Instead, let's advertise that indefinitely many targets are allowed.
Refs:

* https://defs.ircdocs.horse/defs/isupport.html#targmax
* https://github.com/ircdocs/modern-irc/pull/112

This enables a test in https://github.com/ProgVal/irctest/pull/100 (which relies on TARGMAX to detect if the test should run)