### PR TITLE
Add missing argument to ERR_NEEDMOREPARAMS on USER commands.

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3038,7 +3038,7 @@ func userHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 
 	username, realname := msg.Params[0], msg.Params[3]
 	if len(realname) == 0 {
-		rb.Add(nil, server.name, ERR_NEEDMOREPARAMS, client.Nick(), client.t("Not enough parameters"))
+		rb.Add(nil, server.name, ERR_NEEDMOREPARAMS, client.Nick(), "USER", client.t("Not enough parameters"))
 		return false
 	}
 


### PR DESCRIPTION
Refs:

* other instances in the codebase
* https://defs.ircdocs.horse/defs/numerics.html#err-needmoreparams-461
* https://modern.ircdocs.horse/#errneedmoreparams-461

irctest PR: https://github.com/ProgVal/irctest/pull/101