### PR TITLE
docs: added clarifying alternative to registering nick

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -250,6 +250,10 @@ In most IRC servers you can use `NickServ` to register an account. You can do th
 To register an account, use:
 
     /NS REGISTER <password>
+or 
+```
+/msg NickServ REGISTER <password>
+```
 
 This is the way to go if you want to use a regular password. `<password>` is your password, your current nickname will become your username. Your password cannot contain spaces, but make sure to use a strong one anyway.
 

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -76,6 +76,14 @@ Once you have registered your account, you must configure SASL in your client, s
 
 If your client doesn't support SASL, you can typically use the "server password" (`PASS`) field in your client to log into your account automatically when connecting. Set the server password to `accountname:accountpassword`, where `accountname` is your account name and `accountpassword` is your account password.
 
+# Logging with registered nick
+
+Once you've registered a nick, you can use the following to login:
+```
+/msg NickServ identify <nick> <password>
+```
+Please note that, you unlike other softwares, you cannot first `/nick <nick>` and identify with a password.
+
 # Channel registration
 
 Once you've registered your nickname, you can use it to register channels. By default, channels are ephemeral; they go away when there are no longer any users in the channel, or when the server is restarted. Registering a channel gives you permanent control over it, and ensures that its settings will persist. To register a channel, send a message to `ChanServ`:


### PR DESCRIPTION
Added a clarification point for logging into the registered nick once registered. Also noted the difference between other daemons. I think it'd be better if we mention this explicitly.