### PR TITLE
irc: fix dropped errors

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -572,6 +572,9 @@ func (am *AccountManager) setPassword(accountName string, password string, hasPr
 
 	err = am.server.store.Update(func(tx *buntdb.Tx) error {
 		curCredStr, err := tx.Get(credKey)
+		if err != nil {
+			return err
+		}
 		if credStr != curCredStr {
 			return errCASFailed
 		}
@@ -752,6 +755,9 @@ func (am *AccountManager) addRemoveCertfp(account, certfp string, add bool, hasP
 	certfpKey := fmt.Sprintf(keyCertToAccount, certfp)
 	err = am.server.store.Update(func(tx *buntdb.Tx) error {
 		curCredStr, err := tx.Get(credKey)
+		if err != nil {
+			return err
+		}
 		if credStr != curCredStr {
 			return errCASFailed
 		}


### PR DESCRIPTION
This fixes two dropped `err` variables in the `irc` package.