### PR TITLE
docker: downgrade alpine to 3.13 again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## build ergo binary
-FROM golang:1.17-alpine AS build-env
+FROM golang:1.17-alpine3.13 AS build-env
 
 RUN apk add -U --force-refresh --no-cache --purge --clean-protected -l -u make
 


### PR DESCRIPTION
See https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2 ;
this maintains compatibility with older, buggy versions of docker and runc.
Alpine 3.13 is supported until 2022-11-01.