### PR TITLE
kline and dline accept nickname as input, blacklist mask/ip

### DIFF
--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -268,7 +268,7 @@ func (clients *ClientManager) AllWithCapsNotify(capabs ...caps.Capability) (sess
 func (clients *ClientManager) FindAll(userhost string) (set ClientSet) {
 	set = make(ClientSet)
 
-	userhost, err := CanonicalizeMaskWildcard(userhost)
+	userhost, err := CanonicalizeMaskWildcard(userhost, false, nil)
 	if err != nil {
 		return set
 	}

--- a/irc/database.go
+++ b/irc/database.go
@@ -488,7 +488,7 @@ func schemaChangeV6ToV7(config *Config, tx *buntdb.Tx) error {
 		}
 		newCookedValue := make(map[string]maskInfoV7)
 		for _, mask := range masks {
-			normalizedMask, err := CanonicalizeMaskWildcard(mask)
+			normalizedMask, err := CanonicalizeMaskWildcard(mask, false, nil)
 			if err != nil {
 				continue
 			}

--- a/irc/help.go
+++ b/irc/help.go
@@ -183,7 +183,7 @@ DEOPER removes the IRCop privileges granted to you by a successful /OPER.`,
 	},
 	"dline": {
 		oper: true,
-		text: `DLINE [ANDKILL] [MYSELF] [duration] <ip>/<net> [ON <server>] [reason [| oper reason]]
+		text: `DLINE [ANDKILL] [MYSELF] [duration] <ip>/<net>/<nick> [ON <server>] [reason [| oper reason]]
 DLINE LIST
 
 Bans an IP address or network from connecting to the server. If the duration is
@@ -204,6 +204,9 @@ from. If "MYSELF" is not given, trying to DLINE yourself will result in an error
 <net> is specified in typical CIDR notation. For example:
 	127.0.0.1/8
 	8.8.8.8/24
+
+Note that if you instead type the nickname of a user who is currently logged in, their IP
+address will automatically be d-lined.
 
 ON <server> specifies that the ban is to be set on that specific server.
 
@@ -273,7 +276,7 @@ supplied.`,
 	},
 	"kline": {
 		oper: true,
-		text: `KLINE [ANDKILL] [MYSELF] [duration] <mask> [ON <server>] [reason [| oper reason]]
+		text: `KLINE [ANDKILL] [MYSELF] [duration] <mask>/<nick> [ON <server>] [reason [| oper reason]]
 KLINE LIST
 
 Bans a mask from connecting to the server. If the duration is given then only for that
@@ -293,6 +296,9 @@ from. If "MYSELF" is not given, trying to KLINE yourself will result in an error
 <mask> is specified in typical IRC format. For example:
 	dan
 	dan!5*@127.*
+
+Note that if you instead type the nickname of a user who is currently logged in, their mask
+will automatically be k-lined.
 
 ON <server> specifies that the ban is to be set on that specific server.
 

--- a/irc/uban.go
+++ b/irc/uban.go
@@ -72,7 +72,7 @@ func parseUbanTarget(param string) (target ubanTarget, err error) {
 	}
 
 	if strings.IndexByte(param, '!') != -1 || strings.IndexByte(param, '@') != -1 {
-		canonicalized, cErr := CanonicalizeMaskWildcard(param)
+		canonicalized, cErr := CanonicalizeMaskWildcard(param, false, nil)
 		if cErr != nil {
 			err = errInvalidParams
 			return

--- a/irc/usermaskset.go
+++ b/irc/usermaskset.go
@@ -37,7 +37,7 @@ func NewUserMaskSet() *UserMaskSet {
 
 // Add adds the given mask to this set.
 func (set *UserMaskSet) Add(mask, creatorNickmask, creatorAccount string) (maskAdded string, err error) {
-	casefoldedMask, err := CanonicalizeMaskWildcard(mask)
+	casefoldedMask, err := CanonicalizeMaskWildcard(mask, false, nil)
 	if err != nil {
 		return
 	}
@@ -68,7 +68,7 @@ func (set *UserMaskSet) Add(mask, creatorNickmask, creatorAccount string) (maskA
 
 // Remove removes the given mask from this set.
 func (set *UserMaskSet) Remove(mask string) (maskRemoved string, err error) {
-	mask, err = CanonicalizeMaskWildcard(mask)
+	mask, err = CanonicalizeMaskWildcard(mask, false, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This change allows you to mention a client by nickname in `/kline` or `/dline` commands. This is intended to replicate the behavior of these commands in the Unreal daemon.

It should be noted that this replaces the current functionality in which if you type `/kline <nick>` without a bang or strude it defaults to the mask nick!*@*. However, typing a nick into the `/dline` command currently returns an error so this does not intrude upon any current functionality. (In addition, note that this only "adds a step" in between the final check of each command's attempt to parse the input and either an error or a fallback solution in the case of `/kline` so this will not intrude on a kline or dline that is made with an explicit mask or ip in the input.)

How to use: `/kline <nick>`, `/kline andkill <nick>`, `/kline andkill 60m <nick>`, `/dline <nick>`, etc.

This pull request also updates the documentation for each of these two commands.