### PR TITLE
Update docker repo location

### DIFF
--- a/distrib/docker/README.md
+++ b/distrib/docker/README.md
@@ -1,7 +1,7 @@
 # Ergo Docker
 
-This folder holds Ergo's Dockerfile and related materials. Ergo
-is published automatically to the GitHub Container Registry at
+This folder holds Ergo's Docker compose file. The Dockerfile is in the root 
+directory. Ergo is published automatically to the GitHub Container Registry at
 [ghcr.io/ergochat/ergo](https://ghcr.io/ergochat/ergo).
 
 Most users should use either the `stable` tag (corresponding to the

--- a/distrib/docker/docker-compose.yml
+++ b/distrib/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   ergo:
-    image: ergochat/ergo:latest
+    image: ghcr.io/ergochat/ergo:stable
     ports:
       - "6667:6667/tcp"
       - "6697:6697/tcp"

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -135,11 +135,11 @@ To start the server, type `./ergo run` and hit enter, and the server should be r
 
 ## Docker
 
-1. Pull the latest version of Ergo: `docker pull oragono/oragono:latest`
-1. Create a volume for persistent data: `docker volume create oragono-data`
-1. Run the container, exposing the default ports: `docker run -d --name oragono -v oragono-data:/ircd-data -p 6667:6667 -p 6697:6697 ghcr.io/ergochat/ergo:stable`
+1. Pull the latest version of Ergo: `docker pull ghcr.io/ergochat/ergo:stable`
+1. Create a volume for persistent data: `docker volume create ergo-data`
+1. Run the container, exposing the default ports: `docker run -d --name ergo -v ergo-data:/ircd -p 6667:6667 -p 6697:6697 ghcr.io/ergochat/ergo:stable`
 
-For further information and a sample docker-compose file see the separate [Docker documentation](https://github.com/oragono/oragono/blob/master/distrib/docker/README.md).
+For further information and a sample docker-compose file see the separate [Docker documentation](https://github.com/ergochat/ergo/blob/master/distrib/docker/README.md).
 
 
 ## Building from source
@@ -170,8 +170,8 @@ Ergo can also be configured using environment variables, using the following tec
 
 1. Find the "path" of the config variable you want to override in the YAML file, e.g., `server.websockets.allowed-origins`
 1. Convert each path component from "kebab case" to "screaming snake case", e.g., `SERVER`, `WEBSOCKETS`, and `ALLOWED_ORIGINS`.
-1. Prepend `ORAGONO` to the components, then join them all together using `__` as the separator, e.g., `ORAGONO__SERVER__WEBSOCKETS__ALLOWED_ORIGINS`.
-1. Set the environment variable of this name to a JSON (or YAML) value that will be deserialized into this config field, e.g., `export ORAGONO__SERVER__WEBSOCKETS__ALLOWED_ORIGINS='["https://irc.example.com", "https://chat.example.com"]'`
+1. Prepend `ERGO` to the components, then join them all together using `__` as the separator, e.g., `ERGO__SERVER__WEBSOCKETS__ALLOWED_ORIGINS`.
+1. Set the environment variable of this name to a JSON (or YAML) value that will be deserialized into this config field, e.g., `export ERGO__SERVER__WEBSOCKETS__ALLOWED_ORIGINS='["https://irc.example.com", "https://chat.example.com"]'`
 
 However, settings that were overridden using this technique cannot be rehashed --- changing them will require restarting the server.
 
@@ -1134,7 +1134,7 @@ Note that after a failed script invocation, Ergo will proceed to check the crede
 
 ## DNSBLs and other IP checking systems
 
-Similarly, Ergo can be configured to call arbitrary scripts to validate user IPs. These scripts can either reject the connection, or require that the user log in with SASL. In particular, we provide an [oragono-dnsbl](https://github.com/oragono/oragono-dnsbl) plugin for querying DNSBLs.
+Similarly, Ergo can be configured to call arbitrary scripts to validate user IPs. These scripts can either reject the connection, or require that the user log in with SASL. In particular, we provide an [ergo-dnsbl](https://github.com/ergochat/ergo-dnsbl) plugin for querying DNSBLs.
 
 The API is similar to the auth-script API described above (one line of JSON in, one line of JSON out). The input is a JSON dictionary with the following keys:
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -137,7 +137,7 @@ To start the server, type `./ergo run` and hit enter, and the server should be r
 
 1. Pull the latest version of Ergo: `docker pull oragono/oragono:latest`
 1. Create a volume for persistent data: `docker volume create oragono-data`
-1. Run the container, exposing the default ports: `docker run -d --name oragono -v oragono-data:/ircd-data -p 6667:6667 -p 6697:6697 oragono/oragono:latest`
+1. Run the container, exposing the default ports: `docker run -d --name oragono -v oragono-data:/ircd-data -p 6667:6667 -p 6697:6697 ghcr.io/ergochat/ergo:stable`
 
 For further information and a sample docker-compose file see the separate [Docker documentation](https://github.com/oragono/oragono/blob/master/distrib/docker/README.md).
 


### PR DESCRIPTION
In the main manual doc, and the Docker compose reference file, the image repo location appears to be out of date.

The former was referencing `oragono/oragono:latest` and the latter, `ergochat/ergo`, both on Docker Hub. Neither of those repos have seen a push in >= 6 months.

This PR updates both locations to be consistent with the Docker specific instructions at `distrib/docker/README.md`. I have updated both references to `ghcr.io/ergochat/ergo:stable` accordingly, and tested that the compose file deploys + the app functions:

```
$ podman-compose up -d
['podman', '--version', '']
using podman version: 3.4.3-dev
** excluding:  set()
podman pod create --name=ergo --share net --infra-name=ergo_infra -p 6667:6667/tcp -p 6697:6697/tcp
a2e66bc794e633a70060a60ccad585e42ac100afc8906bc6969395f6cfbe4d3f
exit code: 0
podman volume inspect ergo_data || podman volume create ergo_data
['podman', 'volume', 'inspect', 'ergo_data']
Error: error inspecting object: no such volume ergo_data
['podman', 'volume', 'create', '--label', 'io.podman.compose.project=ergo', '--label', 'com.docker.compose.project=ergo', 'ergo_data']
['podman', 'volume', 'inspect', 'ergo_data']
podman run --name=ergo_ergo_1 -d --pod=ergo --label io.podman.compose.config-hash=123 --label io.podman.compose.project=ergo --label io.podman.compose.version=0.0.1 --label com.docker.compose.project=ergo --label com.docker.compose.project.working_dir=/home/ec2-user/ergo --label com.docker.compose.project.config_files=docker-compose.yml --label com.docker.compose.container-number=1 --label com.docker.compose.service=ergo -v ergo_data:/ircd --add-host ergo:127.0.0.1 --add-host ergo_ergo_1:127.0.0.1 ghcr.io/ergochat/ergo:stable
5dc3627010014bb6287a64fb6bd6151cf9f9dfe6528fde7f3886df2183116ec1
exit code: 0

$ docker ps -a
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
CONTAINER ID  IMAGE                         COMMAND     CREATED        STATUS            PORTS                                           NAMES
453fc9957e17  k8s.gcr.io/pause:3.5                      4 seconds ago  Up 4 seconds ago  0.0.0.0:6667->6667/tcp, 0.0.0.0:6697->6697/tcp  ergo_infra
5dc362701001  ghcr.io/ergochat/ergo:stable              3 seconds ago  Up 3 seconds ago  0.0.0.0:6667->6667/tcp, 0.0.0.0:6697->6697/tcp  ergo_ergo_1

$ docker logs ergo_ergo_1
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
Oper username:password is admin:REDACTED
2021/12/03 19:48:05 making self-signed certificates
2021/12/03 19:48:05  making cert for :6697 listener
2021/12/03 19:48:05   Certificate created at fullchain.pem : privkey.pem
2021-12-03T19:48:05.369Z : info  : server     : ergo-2.8.0-c70e518eed89d5d6 starting
2021-12-03T19:48:05.369Z : info  : server     : Using config file : ircd.yaml
2021-12-03T19:48:05.369Z : info  : server     : Using datastore : ircd.db
2021-12-03T19:48:05.369Z : warn  : server     : database does not exist, creating it : ircd.db
2021-12-03T19:48:05.372Z : info  : server     : Proxied IPs will be accepted from : localhost
2021-12-03T19:48:05.372Z : info  : listeners  : now listening on :6697, tls=true, proxy=false, tor=false, websocket=false.
2021-12-03T19:48:05.372Z : info  : listeners  : now listening on :6667, tls=false, proxy=false, tor=false, websocket=false.
2021-12-03T19:48:05.372Z : warn  : listeners  : Warning: your server is configured with public plaintext listener :6667. Consider disabling it for improved security and privacy.
2021-12-03T19:48:05.372Z : info  : server     : Server running
```