### PR TITLE
Build arm64 container images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,10 @@ name: 'ghcr'
 on:
   push:
     branches:
-      - "ci"
+      - "master"
+      - "stable"
+    tags:
+      - 'v*'
 
 env:
   REGISTRY: ghcr.io
@@ -35,7 +38,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build and public image
+      - name: Build and publish image
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,34 +3,43 @@ name: 'ghcr'
 on:
   push:
     branches:
-      - "master"
-      - "stable"
-    tags:
-      - 'v*'
+      - "ci"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
-    name: 'Build'
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: "Build:checkout"
+      - name: Checkout Git repository
         uses: actions/checkout@v2
-      - name: "Build:meta"
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ghcr.io/ergochat/ergo           
-      - name: "Build:login"
+
+      - name: Authenticate to container registry
         uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Build:dockerimage'
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Setup Docker buildx driver
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and public image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds support for building Docker container images for the `aarch64` (aka `arm64`) platform. Among other hardware targets, this will allow Ergo to be deployed on the AWS EC2 instance families running the ARM Graviton processor line.

See my [test run](https://github.com/erincerys/ergo/runs/4415128484?check_suite_focus=true) of this action here, and the [GHCR page of my fork](https://github.com/erincerys/ergo/pkgs/container/ergo) for proof of the additional platform.

Minor additional refactor:
- Build task descriptions prettified
- Environment variables created and referenced in action configuration aspects
- White space added for readability