### PR TITLE
send `*` for WHOX o (oplevel) instead of `0`

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3319,9 +3319,9 @@ func (client *Client) rplWhoReply(channel *Channel, target *Client, rb *Response
 		}
 		params = append(params, fAccount)
 	}
-	if fields.Has('o') { // target's channel power level
-		//TODO: implement this
-		params = append(params, "0")
+	if fields.Has('o') {
+		// channel oplevel, not implemented
+		params = append(params, "*")
 	}
 	if fields.Has('r') {
 		params = append(params, details.realname)


### PR DESCRIPTION
Jobe points out that `0` is a valid oplevel in some contexts,
`*` is a better placeholder for "unimplemented".