### PR TITLE
anope2json certfp support

### DIFF
--- a/distrib/anope/anope2json.py
+++ b/distrib/anope/anope2json.py
@@ -87,17 +87,14 @@ ANOPE_MODENAME_TO_MODE = {
 # verify that a certfp appears to be a hex-encoded SHA-256 fingerprint;
 # if it's anything else, silently ignore it
 def validate_certfps(certobj):
-    certobj = certobj.split()
     certfps = []
-    for fingerprint in certobj:
+    for fingerprint in certobj.split():
         try:
             dec = binascii.unhexlify(fingerprint)
         except:
             continue
         if len(dec) == 32:
             certfps.append(fingerprint)
-        else:
-            continue
     return certfps
 
 def convert(infile):

--- a/distrib/anope/anope2json.py
+++ b/distrib/anope/anope2json.py
@@ -86,15 +86,19 @@ ANOPE_MODENAME_TO_MODE = {
 
 # verify that a certfp appears to be a hex-encoded SHA-256 fingerprint;
 # if it's anything else, silently ignore it
-def validate_certfp(enc):
-    try:
-        dec = binascii.unhexlify(enc)
-    except:
-        return None
-    if len(dec) == 32:
-        return enc.lower()
-    else:
-        return None
+def validate_certfps(certobj):
+    certobj = certobj.split()
+    certfps = []
+    for fingerprint in certobj:
+        try:
+            dec = binascii.unhexlify(fingerprint)
+        except:
+            continue
+        if len(dec) == 32:
+            certfps.append(fingerprint)
+        else:
+            continue
+    return certfps
 
 def convert(infile):
     out = {
@@ -114,12 +118,7 @@ def convert(infile):
             userdata = {'name': username, 'hash': obj.kv['pass'], 'email': obj.kv['email']}
             certobj = obj.kv.get('cert')
             if certobj:
-                certobj = certobj.split()
-                userdata['certfps'] = list()
-                for cert in certobj:
-                    certfp = validate_certfp(cert)
-                    if certfp:
-                        userdata['certfps'].append(certfp)
+                userdata['certfps'] = validate_certfps(certobj)
             out['users'][username] = userdata
         elif obj.type == 'NickAlias':
             username = obj.kv['nc']

--- a/distrib/anope/anope2json.py
+++ b/distrib/anope/anope2json.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 
-import re
+import binascii
 import json
 import logging
+import re
 import sys
 from collections import defaultdict, namedtuple
 
@@ -83,6 +84,18 @@ ANOPE_MODENAME_TO_MODE = {
     'SECRET': 's',
 }
 
+# verify that a certfp appears to be a hex-encoded SHA-256 fingerprint;
+# if it's anything else, silently ignore it
+def validate_certfp(enc):
+    try:
+        dec = binascii.unhexlify(enc)
+    except:
+        return None
+    if len(dec) == 32:
+        return enc.lower()
+    else:
+        return None
+
 def convert(infile):
     out = {
         'version': 1,
@@ -99,6 +112,14 @@ def convert(infile):
         if obj.type == 'NickCore':
             username = obj.kv['display']
             userdata = {'name': username, 'hash': obj.kv['pass'], 'email': obj.kv['email']}
+            certobj = obj.kv.get('cert')
+            if certobj:
+                certobj = certobj.split()
+                userdata['certfps'] = list()
+                for cert in certobj:
+                    certfp = validate_certfp(cert)
+                    if certfp:
+                        userdata['certfps'].append(certfp)
             out['users'][username] = userdata
         elif obj.type == 'NickAlias':
             username = obj.kv['nc']


### PR DESCRIPTION
This resolves the Anope part of #1864, allowing for the automatic import of fingerprints for certfp authentication as part of a database conversion.