### PR TITLE
bump database version generated by importer

### DIFF
--- a/irc/import.go
+++ b/irc/import.go
@@ -20,7 +20,7 @@ const (
 	// XXX instead of referencing, e.g., keyAccountExists, we should write in the string literal
 	// (to ensure that no matter what code changes happen elsewhere, we're still producing a
 	// db of the hardcoded version)
-	importDBSchemaVersion = 19
+	importDBSchemaVersion = 22
 )
 
 type userImport struct {


### PR DESCRIPTION
This should have been done in 8b2f6de3e0b9, since we updated both
the database schema and the importer then.