### PR TITLE
correctly account for nickname in CAP LS arithmetic

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -527,9 +527,9 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		// 1. WeeChat 1.4 won't accept the CAP reply unless it contains the server.name source
 		// 2. old versions of Kiwi and The Lounge can't parse multiline CAP LS 302 (#661),
 		// so try as hard as possible to get the response to fit on one line.
-		// :server.name CAP * LS * :<tokens>\r\n
-		// 1           [ 7   ]  [4 ]        [2 ]
-		maxLen := (MaxLineLen - 2) - 1 - len(server.name) - 7 - len(subCommand) - 4
+		// :server.name CAP nickname LS * :<tokens>\r\n
+		// 1           [5  ]        1  [4 ]        [2 ]
+		maxLen := (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 1 - len(subCommand) - 4
 		capLines := cset.Strings(version, values, maxLen)
 		for i, capStr := range capLines {
 			if version >= caps.Cap302 && i < len(capLines)-1 {


### PR DESCRIPTION
Before, CAP LS responses after registration could actually be truncated:

```
:ircs.redacted.site CAP asdfasdfasdf LS :account-notify account-tag away-notify batch cap-notify chghost draft/account-registration=before-connect,email-required draft/channel-rename draft/chathistory draft/event-playback draft/extended-monitor draft/languages=1,en draft/multiline=max-bytes=4096,max-lines=24 draft/relaymsg=/ echo-message ergo.chat/nope extended-join invite-notify labeled-response message-tags multi-prefix sasl=PLAIN,EXTERNAL server-time setname userhost-in-names znc.in/playback znc.in/sel
```

After this change, in my testing, we can produce a CAP LS response of exactly 510 bytes (not counting the `\r\n`), then adding a single additional character to the nickname pushes a token onto the next line:

```
nick aaaaaaaaaaa
:aaaaaaaaaaaa!~u@m5gy8jpgzbefg.irc NICK aaaaaaaaaaa
cap ls 302
:oragono.test CAP aaaaaaaaaaa LS * :account-notify account-tag away-notify batch cap-notify chghost draft/account-registration=before-connect,email-required draft/channel-rename draft/chathistory draft/event-playback draft/extended-monitor draft/languages=1,en draft/multiline=max-bytes=2048,max-lines=24 draft/relaymsg=/ echo-message ergo.chat/nope extended-join invite-notify labeled-response message-tags multi-prefix sasl=PLAIN,EXTERNAL server-time setname sts=duration=31536000,port=6697 userhost-in-names
:oragono.test CAP aaaaaaaaaaa LS :znc.in/playback znc.in/self-message
nick aaaaaaaaaaaa
:aaaaaaaaaaa!~u@m5gy8jpgzbefg.irc NICK aaaaaaaaaaaa
cap ls 302
:oragono.test CAP aaaaaaaaaaaa LS * :account-notify account-tag away-notify batch cap-notify chghost draft/account-registration=before-connect,email-required draft/channel-rename draft/chathistory draft/event-playback draft/extended-monitor draft/languages=1,en draft/multiline=max-bytes=2048,max-lines=24 draft/relaymsg=/ echo-message ergo.chat/nope extended-join invite-notify labeled-response message-tags multi-prefix sasl=PLAIN,EXTERNAL server-time setname sts=duration=31536000,port=6697
:oragono.test CAP aaaaaaaaaaaa LS :userhost-in-names znc.in/playback znc.in/self-message
```