### PR TITLE
distrib: add OpenRC init scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ ergo run     # server should be ready to go!
 Some platforms/distros also have Ergo packages maintained for them:
 
 * Arch Linux [AUR](https://aur.archlinux.org/packages/ergochat/) - Maintained by [Jason Papakostas (@vith)](https://github.com/vith).
+* [Gentoo Linux](https://packages.gentoo.org/packages/net-irc/ergo) - Maintained by [Sam James (@thesamesam)](https://github.com/thesamesam).
 
 ### Using Docker
 

--- a/distrib/openrc/ergo.confd
+++ b/distrib/openrc/ergo.confd
@@ -1,0 +1,2 @@
+# /etc/conf.d/ergo: config file for /etc/init.d/ergo
+ERGO_CONFIGFILE="/etc/ergo/ircd.yaml"

--- a/distrib/openrc/ergo.initd
+++ b/distrib/openrc/ergo.initd
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+command=/usr/bin/ergo
+command_args="run --conf ${ERGO_CONFIGFILE:-"/etc/ergo/ircd.yaml"}"
+command_background=true
+extra_started_commands="reload"
+pidfile=/var/run/ergo.pid
+name="ergo"
+description="ergo IRC daemon"
+
+depend() {
+	use dns
+	provide ircd
+}
+
+reload() {
+	ebegin "Reloading ${RC_SVCNAME}"
+	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+	eend $?
+}


### PR DESCRIPTION
Written originally for Gentoo but should work
on Alpine and other OpenRC-consuming distros too.

Signed-off-by: Sam James <sam@gentoo.org>