### PR TITLE
show arbitrary IP in WHOX

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3265,7 +3265,8 @@ func (client *Client) rplWhoReply(channel *Channel, target *Client, rb *Response
 		fIP := "255.255.255.255"
 		if canSeeIPs || client == target {
 			// you can only see a target's IP if they're you or you're an oper
-			fIP = target.IPString()
+			ip, _ := target.getWhoisActually()
+			fIP = ip.String()
 		}
 		params = append(params, fIP)
 	}


### PR DESCRIPTION
This extends #1650 to cover WHO as well as WHOIS