### PR TITLE
fix #1896

### DIFF
--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -101,8 +101,10 @@ func (clients *ClientManager) SetNick(client *Client, session *Session, newNick 
 	// on previous versions of Ergo:
 	if newNick != accountName {
 		// can't contain "disfavored" characters like <, or start with a $ because
-		// it collides with the massmessage mask syntax:
-		if strings.ContainsAny(newNick, disfavoredNameCharacters) || strings.HasPrefix(newNick, "$") {
+		// it collides with the massmessage mask syntax. '0' conflicts with the use of 0
+		// as a placeholder in WHOX (#1896):
+		if strings.ContainsAny(newNick, disfavoredNameCharacters) || strings.HasPrefix(newNick, "$") ||
+			newNick == "0" {
 			return "", errNicknameInvalid, false
 		}
 	}


### PR DESCRIPTION
Don't allow any new uses of 0 as a nickname, since it conflicts with
the use of 0 as a placeholder for account name in WHOX.