### PR TITLE
use exact integer parsing for znc.in/playback

### DIFF
--- a/irc/misc_test.go
+++ b/irc/misc_test.go
@@ -12,6 +12,11 @@ func TestZncTimestampParser(t *testing.T) {
 	assertEqual(zncWireTimeToTime("1558338348.988"), time.Unix(1558338348, 988000000).UTC(), t)
 	assertEqual(zncWireTimeToTime("1558338348.9"), time.Unix(1558338348, 900000000).UTC(), t)
 	assertEqual(zncWireTimeToTime("1558338348"), time.Unix(1558338348, 0).UTC(), t)
+	assertEqual(zncWireTimeToTime("1558338348.99999999999999999999999999999"), time.Unix(1558338348, 999999999).UTC(), t)
+	assertEqual(zncWireTimeToTime("1558338348.999999999111111111"), time.Unix(1558338348, 999999999).UTC(), t)
+	assertEqual(zncWireTimeToTime("1558338348.999999991111111111"), time.Unix(1558338348, 999999991).UTC(), t)
 	assertEqual(zncWireTimeToTime(".988"), time.Unix(0, 988000000).UTC(), t)
+	assertEqual(zncWireTimeToTime("0"), time.Unix(0, 0).UTC(), t)
 	assertEqual(zncWireTimeToTime("garbage"), time.Unix(0, 0).UTC(), t)
+	assertEqual(zncWireTimeToTime(""), time.Unix(0, 0).UTC(), t)
 }

--- a/irc/znc.go
+++ b/irc/znc.go
@@ -51,11 +51,18 @@ func zncWireTimeToTime(str string) (result time.Time) {
 		secondsPortion = str
 	} else {
 		secondsPortion = str[:dot]
-		fracPortion = str[dot:]
+		fracPortion = str[dot+1:]
 	}
 	seconds, _ := strconv.ParseInt(secondsPortion, 10, 64)
-	fraction, _ := strconv.ParseFloat(fracPortion, 64)
-	return time.Unix(seconds, int64(fraction*1000000000)).UTC()
+	// truncate to nanosecond resolution if necessary
+	if len(fracPortion) > 9 {
+		fracPortion = fracPortion[:9]
+	}
+	fracSeconds, _ := strconv.ParseInt(fracPortion, 10, 64)
+	for i := 0; i < (9 - len(fracPortion)); i++ {
+		fracSeconds *= 10
+	}
+	return time.Unix(seconds, fracSeconds).UTC()
 }
 
 func timeToZncWireTime(t time.Time) (result string) {


### PR DESCRIPTION
Unclear whether this makes a difference in any real world cases, but this is the Right Way to do it.