### PR TITLE
distrib: refine OpenRC init scripts

### DIFF
--- a/distrib/openrc/ergo.confd
+++ b/distrib/openrc/ergo.confd
@@ -1,2 +1,3 @@
 # /etc/conf.d/ergo: config file for /etc/init.d/ergo
 ERGO_CONFIGFILE="/etc/ergo/ircd.yaml"
+ERGO_USERNAME="ergo"

--- a/distrib/openrc/ergo.initd
+++ b/distrib/openrc/ergo.initd
@@ -1,15 +1,28 @@
 #!/sbin/openrc-run
-command=/usr/bin/ergo
-command_args="run --conf ${ERGO_CONFIGFILE:-"/etc/ergo/ircd.yaml"}"
-command_background=true
-extra_started_commands="reload"
-pidfile=/var/run/ergo.pid
-name="ergo"
+name=${RC_SVCNAME}
 description="ergo IRC daemon"
+
+command=/usr/bin/ergo
+command_args="run --conf ${ERGO_CONFIGFILE:-'/etc/ergo/ircd.yaml'}"
+command_user=${ERGO_USERNAME:-ergo}
+command_background=true
+
+pidfile=/var/run/${RC_SVCNAME}.pid
+
+output_log="/var/log/${RC_SVCNAME}.out"
+error_log="/var/log/${RC_SVCNAME}.err"
+# --wait: to wait 1 second after launching to see if it survived startup
+start_stop_daemon_args="--wait 1000"
+
+extra_started_commands="reload"
 
 depend() {
 	use dns
 	provide ircd
+}
+
+start_pre() {
+	checkpath --owner ${command_user}:${command_user} --mode 0640 --file /var/log/${RC_SVCNAME}.out /var/log/${RC_SVCNAME}.err
 }
 
 reload() {


### PR DESCRIPTION
- Add logging to init script
- Add delay so OpenRC realises if we crashed quickly b/c of e.g. bad config
   file
- General cleanups (like supporting multiple instances, style changes)

This should make it a lot easier to see what's going wrong when something
breaks.

Bug: ergochat/ergo#1914
Signed-off-by: Sam James <sam@gentoo.org>