### PR TITLE
make SAREGISTER override DEFCON

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -356,7 +356,7 @@ func (am *AccountManager) Register(client *Client, account string, callbackNames
 	config := am.server.Config()
 
 	// final "is registration allowed" check:
-	if !(config.Accounts.Registration.Enabled || callbackNamespace == "admin") || am.server.Defcon() <= 4 {
+	if callbackNamespace != "admin" && (!config.Accounts.Registration.Enabled || am.server.Defcon() <= 4) {
 		return errFeatureDisabled
 	}
 


### PR DESCRIPTION
DEFCON 4 and lower were blocking SAREGISTER. This is wrong; admins should be
allowed to make new accounts even under DEFCON (this may be needed
specifically to work around the DEFCON restriction).