### PR TITLE
upgrade to go 1.18, start using generics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "setup go"
         uses: "actions/setup-go@v2"
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: "install python3-pytest"
         run: "sudo apt install -y python3-pytest"
       - name: "make install"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## build ergo binary
-FROM golang:1.17-alpine3.13 AS build-env
+FROM golang:1.18-alpine3.13 AS build-env
 
 RUN apk add -U --force-refresh --no-cache --purge --clean-protected -l -u make git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ergochat/ergo
 
-go 1.17
+go 1.18
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -177,10 +177,7 @@ func (channel *Channel) ExportRegistration(includeFlags uint) (info RegisteredCh
 		info.Bans = channel.lists[modes.BanMask].Masks()
 		info.Invites = channel.lists[modes.InviteMask].Masks()
 		info.Excepts = channel.lists[modes.ExceptMask].Masks()
-		info.AccountToUMode = make(map[string]modes.Mode)
-		for account, mode := range channel.accountToUMode {
-			info.AccountToUMode[account] = mode
-		}
+		info.AccountToUMode = utils.CopyMap(channel.accountToUMode)
 	}
 
 	if includeFlags&IncludeSettings != 0 {

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -26,17 +26,17 @@ type ChannelManager struct {
 	sync.RWMutex // tier 2
 	// chans is the main data structure, mapping casefolded name -> *Channel
 	chans               map[string]*channelManagerEntry
-	chansSkeletons      utils.StringSet // skeletons of *unregistered* chans
-	registeredChannels  utils.StringSet // casefolds of registered chans
-	registeredSkeletons utils.StringSet // skeletons of registered chans
-	purgedChannels      utils.StringSet // casefolds of purged chans
+	chansSkeletons      utils.HashSet[string] // skeletons of *unregistered* chans
+	registeredChannels  utils.HashSet[string] // casefolds of registered chans
+	registeredSkeletons utils.HashSet[string] // skeletons of registered chans
+	purgedChannels      utils.HashSet[string] // casefolds of purged chans
 	server              *Server
 }
 
 // NewChannelManager returns a new ChannelManager.
 func (cm *ChannelManager) Initialize(server *Server) {
 	cm.chans = make(map[string]*channelManagerEntry)
-	cm.chansSkeletons = make(utils.StringSet)
+	cm.chansSkeletons = make(utils.HashSet[string])
 	cm.server = server
 
 	// purging should work even if registration is disabled
@@ -66,8 +66,8 @@ func (cm *ChannelManager) loadRegisteredChannels(config *Config) {
 	cm.Lock()
 	defer cm.Unlock()
 
-	cm.registeredChannels = make(utils.StringSet, len(rawNames))
-	cm.registeredSkeletons = make(utils.StringSet, len(rawNames))
+	cm.registeredChannels = make(utils.HashSet[string], len(rawNames))
+	cm.registeredSkeletons = make(utils.HashSet[string], len(rawNames))
 	for _, name := range rawNames {
 		cfname, err := CasefoldChannel(name)
 		if err == nil {

--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -145,8 +145,8 @@ func (reg *ChannelRegistry) AllChannels() (result []string) {
 }
 
 // PurgedChannels returns the set of all casefolded channel names that have been purged
-func (reg *ChannelRegistry) PurgedChannels() (result utils.StringSet) {
-	result = make(utils.StringSet)
+func (reg *ChannelRegistry) PurgedChannels() (result utils.HashSet[string]) {
+	result = make(utils.HashSet[string])
 
 	prefix := fmt.Sprintf(keyChannelPurged, "")
 	reg.server.store.View(func(tx *buntdb.Tx) error {

--- a/irc/client_test.go
+++ b/irc/client_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGenerateBatchID(t *testing.T) {
 	var session Session
-	s := make(utils.StringSet)
+	s := make(utils.HashSet[string])
 
 	count := 100000
 	for i := 0; i < count; i++ {

--- a/irc/config.go
+++ b/irc/config.go
@@ -704,8 +704,8 @@ type Config struct {
 // OperClass defines an assembled operator class.
 type OperClass struct {
 	Title        string
-	WhoisLine    string          `yaml:"whois-line"`
-	Capabilities utils.StringSet // map to make lookups much easier
+	WhoisLine    string                `yaml:"whois-line"`
+	Capabilities utils.HashSet[string] // map to make lookups much easier
 }
 
 // OperatorClasses returns a map of assembled operator classes from the given config.
@@ -743,7 +743,7 @@ func (conf *Config) OperatorClasses() (map[string]*OperClass, error) {
 
 			// create new operclass
 			var oc OperClass
-			oc.Capabilities = make(utils.StringSet)
+			oc.Capabilities = make(utils.HashSet[string])
 
 			// get inhereted info from other operclasses
 			if len(info.Extends) > 0 {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3424,7 +3424,7 @@ func whoHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		// Construct set of channels the client is in.
 		userChannels := make(ChannelSet)
 		for _, channel := range client.Channels() {
-			userChannels[channel] = empty{}
+			userChannels.Add(channel)
 		}
 
 		// Another client is a friend if they share at least one channel, or they are the same client.
@@ -3437,7 +3437,7 @@ func whoHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 				if channel.flags.HasMode(modes.Auditorium) {
 					return false // TODO this should respect +v etc.
 				}
-				if _, present := userChannels[channel]; present {
+				if userChannels.Has(channel) {
 					return true
 				}
 			}

--- a/irc/history/history.go
+++ b/irc/history/history.go
@@ -203,7 +203,7 @@ func (list *Buffer) betweenHelper(start, end Selector, cutoff time.Time, pred Pr
 
 // returns all correspondents, in reverse time order
 func (list *Buffer) allCorrespondents() (results []TargetListing) {
-	seen := make(utils.StringSet)
+	seen := make(utils.HashSet[string])
 
 	list.RLock()
 	defer list.RUnlock()

--- a/irc/import.go
+++ b/irc/import.go
@@ -54,7 +54,7 @@ type databaseImport struct {
 	Channels map[string]channelImport
 }
 
-func serializeAmodes(raw map[string]string, validCfUsernames utils.StringSet) (result []byte, err error) {
+func serializeAmodes(raw map[string]string, validCfUsernames utils.HashSet[string]) (result []byte, err error) {
 	processed := make(map[string]int, len(raw))
 	for accountName, mode := range raw {
 		if len(mode) != 1 {
@@ -80,7 +80,7 @@ func doImportDBGeneric(config *Config, dbImport databaseImport, credsType Creden
 	tx.Set(keySchemaVersion, strconv.Itoa(importDBSchemaVersion), nil)
 	tx.Set(keyCloakSecret, utils.GenerateSecretKey(), nil)
 
-	cfUsernames := make(utils.StringSet)
+	cfUsernames := make(utils.HashSet[string])
 	skeletonToUsername := make(map[string]string)
 	warnSkeletons := false
 

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -24,8 +24,8 @@ var (
 		"MemoServ", "BotServ", "OperServ",
 	}
 
-	restrictedCasefoldedNicks = make(utils.StringSet)
-	restrictedSkeletons       = make(utils.StringSet)
+	restrictedCasefoldedNicks = make(utils.HashSet[string])
+	restrictedSkeletons       = make(utils.HashSet[string])
 )
 
 func performNickChange(server *Server, client *Client, target *Client, session *Session, nickname string, rb *ResponseBuffer) error {

--- a/irc/types.go
+++ b/irc/types.go
@@ -9,28 +9,11 @@ import (
 	"time"
 
 	"github.com/ergochat/ergo/irc/modes"
+	"github.com/ergochat/ergo/irc/utils"
 )
 
-type empty struct{}
-
 // ClientSet is a set of clients.
-type ClientSet map[*Client]empty
-
-// Add adds the given client to this set.
-func (clients ClientSet) Add(client *Client) {
-	clients[client] = empty{}
-}
-
-// Remove removes the given client from this set.
-func (clients ClientSet) Remove(client *Client) {
-	delete(clients, client)
-}
-
-// Has returns true if the given client is in this set.
-func (clients ClientSet) Has(client *Client) bool {
-	_, ok := clients[client]
-	return ok
-}
+type ClientSet = utils.HashSet[*Client]
 
 type memberData struct {
 	modes    *modes.ModeSet
@@ -60,4 +43,4 @@ func (members MemberSet) Has(member *Client) bool {
 }
 
 // ChannelSet is a set of channels.
-type ChannelSet map[*Channel]empty
+type ChannelSet = utils.HashSet[*Channel]

--- a/irc/utils/types.go
+++ b/irc/utils/types.go
@@ -5,13 +5,25 @@ package utils
 
 type empty struct{}
 
-type StringSet map[string]empty
+type HashSet[T comparable] map[T]empty
 
-func (s StringSet) Has(str string) bool {
-	_, ok := s[str]
+func (s HashSet[T]) Has(elem T) bool {
+	_, ok := s[elem]
 	return ok
 }
 
-func (s StringSet) Add(str string) {
-	s[str] = empty{}
+func (s HashSet[T]) Add(elem T) {
+	s[elem] = empty{}
+}
+
+func (s HashSet[T]) Remove(elem T) {
+	delete(s, elem)
+}
+
+func CopyMap[K comparable, V any](input map[K]V) (result map[K]V) {
+	result = make(map[K]V, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return
 }

--- a/irc/znc.go
+++ b/irc/znc.go
@@ -74,7 +74,7 @@ func timeToZncWireTime(t time.Time) (result string) {
 type zncPlaybackTimes struct {
 	start   time.Time
 	end     time.Time
-	targets utils.StringSet // nil for "*" (everything), otherwise the channel names
+	targets utils.HashSet[string] // nil for "*" (everything), otherwise the channel names
 	setAt   time.Time
 }
 
@@ -134,7 +134,7 @@ func zncPlaybackPlayHandler(client *Client, command string, params []string, rb 
 		end = zncWireTimeToTime(params[3])
 	}
 
-	var targets utils.StringSet
+	var targets utils.HashSet[string]
 	var nickTargets []string
 
 	// three cases:
@@ -157,7 +157,7 @@ func zncPlaybackPlayHandler(client *Client, command string, params []string, rb 
 	if params[1] == "*" {
 		playPrivmsgs = true // XXX nil `targets` means "every channel"
 	} else {
-		targets = make(utils.StringSet)
+		targets = make(utils.HashSet[string])
 		for _, targetName := range strings.Split(targetString, ",") {
 			if strings.HasPrefix(targetName, "#") {
 				if cfTarget, err := CasefoldChannel(targetName); err == nil {


### PR DESCRIPTION
This is split off from work I was doing to implement [draft/read-marker](https://github.com/ircv3/ircv3-specifications/pull/489); I figured the part that's a pure refactor made sense as its own PR.