### PR TITLE
genericize atomic config changes

### DIFF
--- a/irc/getters.go
+++ b/irc/getters.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/ergochat/ergo/irc/caps"
 	"github.com/ergochat/ergo/irc/languages"
@@ -16,11 +15,7 @@ import (
 )
 
 func (server *Server) Config() (config *Config) {
-	return (*Config)(atomic.LoadPointer(&server.config))
-}
-
-func (server *Server) SetConfig(config *Config) {
-	atomic.StorePointer(&server.config, unsafe.Pointer(config))
+	return server.config.Get()
 }
 
 func (server *Server) ChannelRegistrationEnabled() bool {

--- a/irc/server.go
+++ b/irc/server.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/ergochat/irc-go/ircfmt"
 	"github.com/okzk/sdnotify"
@@ -66,7 +65,7 @@ type Server struct {
 	channels          ChannelManager
 	channelRegistry   ChannelRegistry
 	clients           ClientManager
-	config            unsafe.Pointer
+	config            utils.ConfigStore[Config]
 	configFilename    string
 	connectionLimiter connection_limits.Limiter
 	ctime             time.Time
@@ -704,7 +703,7 @@ func (server *Server) applyConfig(config *Config) (err error) {
 	config.Server.Cloaks.SetSecret(LoadCloakSecret(server.store))
 
 	// activate the new config
-	server.SetConfig(config)
+	server.config.Set(config)
 
 	// load [dk]-lines, registered users and channels, etc.
 	if initial {

--- a/irc/utils/config.go
+++ b/irc/utils/config.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Shivaram Lingamneni
+// released under the MIT license
+
+package utils
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+/*
+This can be used to implement the following pattern:
+
+1. Load and munge a config (this can be arbitrarily expensive)
+2. Use Set() to install the config
+3. Use Get() to access the config
+4. As long as any individual config is not modified (by any goroutine)
+   after the initial call to Set(), this is free of data races, and Get()
+   is extremely cheap (on amd64 it compiles down to plain MOV instructions).
+*/
+
+type ConfigStore[T any] struct {
+	ptr unsafe.Pointer
+}
+
+func (c *ConfigStore[T]) Get() *T {
+	return (*T)(atomic.LoadPointer(&c.ptr))
+}
+
+func (c *ConfigStore[T]) Set(ptr *T) {
+	atomic.StorePointer(&c.ptr, unsafe.Pointer(ptr))
+}


### PR DESCRIPTION
I verified that this produces the same ASM.

Before:

```
  server.go:319         0x84b1b7                90                              NOPL
  getters.go:19         0x84b1b8                488b90f0000000                  MOVQ 0xf0(AX), DX
  getters.go:19         0x84b1bf                48899424b8000000                MOVQ DX, 0xb8(SP)
```

After:

```
  server.go:318         0x84b1d7                90                              NOPL
  getters.go:18         0x84b1d8                488b90f0000000                  MOVQ 0xf0(AX), DX
  config.go:27          0x84b1df                48899424b8000000                MOVQ DX, 0xb8(SP)
```

Not really happy with the name `ConfigStore`, alternative suggestions welcome :-)