### PR TITLE
Add client auth options

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -60,6 +60,14 @@ server:
             proxy: false
             # set the minimum TLS version:
             min-tls-version: 1.2
+            # By default a client certificate is requested, but it isn't required that the client send any certificates.
+            # Other options are as follows:
+            # A client certificate is requested during the handshake, and at least one valid certificate is required from the client.
+            # client-auth: "require-and-verify"
+            # A client certificate is requested during the handshake, but does not require that the client sends a certificate. If the client does send a certificate it must be valid.
+            # client-auth: "verify-if"
+            # A client certificate is requested during the handshake, and at least one certificate is required from the client, but that certificate is not required to be valid.
+            # client-auth: "require-any"
 
         # Example of a Unix domain socket for proxying:
         # "/tmp/ergo_sock":

--- a/irc/config.go
+++ b/irc/config.go
@@ -61,6 +61,7 @@ type listenerConfigBlock struct {
 	// SNI configuration, with multiple certificates:
 	TLSCertificates []TLSListenConfig `yaml:"tls-certificates"`
 	MinTLSVersion   string            `yaml:"min-tls-version"`
+	ClientAuth      string            `yaml:"client-auth"`
 	Proxy           bool
 	Tor             bool
 	STSOnly         bool `yaml:"sts-only"`
@@ -887,7 +888,17 @@ func loadTlsConfig(config listenerConfigBlock) (tlsConfig *tls.Config, err error
 		// plaintext!
 		return nil, nil
 	}
-	clientAuth := tls.RequestClientCert
+	var clientAuth tls.ClientAuthType
+	switch config.ClientAuth {
+	case "require-any":
+		clientAuth = tls.RequireAnyClientCert
+	case "verify-if":
+		clientAuth = tls.VerifyClientCertIfGiven
+	case "require-and-verify":
+		clientAuth = tls.RequireAndVerifyClientCert
+	default:
+		clientAuth = tls.RequestClientCert
+	}
 	if config.WebSocket {
 		// if Chrome receives a server request for a client certificate
 		// on a websocket connection, it will immediately disconnect:


### PR DESCRIPTION
Allow for some different client side certificate options. For those times when you want to deny or grant access during the TLS handshake.