### PR TITLE
fix #1969

### DIFF
--- a/irc/mysql/history.go
+++ b/irc/mysql/history.go
@@ -45,7 +45,7 @@ const (
 type e struct{}
 
 type MySQL struct {
-	timeout              int64
+	timeout              *int64
 	trackAccountMessages uint32
 	db                   *sql.DB
 	logger               *logger.Manager
@@ -63,13 +63,14 @@ type MySQL struct {
 }
 
 func (mysql *MySQL) Initialize(logger *logger.Manager, config Config) {
+	mysql.timeout = new(int64)
 	mysql.logger = logger
 	mysql.wakeForgetter = make(chan e, 1)
 	mysql.SetConfig(config)
 }
 
 func (mysql *MySQL) SetConfig(config Config) {
-	atomic.StoreInt64(&mysql.timeout, int64(config.Timeout))
+	atomic.StoreInt64(mysql.timeout, int64(config.Timeout))
 	var trackAccountMessages uint32
 	if config.TrackAccountMessages {
 		trackAccountMessages = 1
@@ -554,7 +555,7 @@ func (mysql *MySQL) prepareStatements() (err error) {
 }
 
 func (mysql *MySQL) getTimeout() time.Duration {
-	return time.Duration(atomic.LoadInt64(&mysql.timeout))
+	return time.Duration(atomic.LoadInt64(mysql.timeout))
 }
 
 func (mysql *MySQL) isTrackingAccountMessages() bool {


### PR DESCRIPTION
On a 32-bit architecture, 64-bit atomic loads and stores must be aligned to a
64-bit boundary. Since the (mysql.MySQL) struct is directly included in the
Server struct, it is impossible to guarantee this via the standard technique
of putting the 64-bit value at the beginning of the struct definition
(since the point at which it is included in the parent struct may cross a
64-bit boundary).

This optimization is probably pointless anyway, adding an additional
indirection won't make a difference.