### PR TITLE
Parallelize 'make test'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "make install"
         run: "make install"
       - name: "make test"
-        run: "make test"
+        run: "make test -j 6"
       - name: "make smoke"
         run: "make smoke"
       - name: "make irctest"

--- a/Makefile
+++ b/Makefile
@@ -19,23 +19,19 @@ release:
 capdefs:
 	python3 ./gencapdefs.py > ${capdef_file}
 
-test:
+test: test-capdefs test-irc test-caps test-cloaks test-connection_limits test-email test-flatip test-history test-isupport test-migrations test-modes test-mysql test-passwd test-sno test-utils test-gofmt
+
+test-capdefs:
 	python3 ./gencapdefs.py | diff - ${capdef_file}
-	cd irc && go test . && go vet .
-	cd irc/caps && go test . && go vet .
-	cd irc/cloaks && go test . && go vet .
-	cd irc/connection_limits && go test . && go vet .
-	cd irc/email && go test . && go vet .
-	cd irc/flatip && go test . && go vet .
-	cd irc/history && go test . && go vet .
-	cd irc/isupport && go test . && go vet .
-	cd irc/migrations && go test . && go vet .
-	cd irc/modes && go test . && go vet .
-	cd irc/mysql && go test . && go vet .
-	cd irc/passwd && go test . && go vet .
-	cd irc/sno && go test . && go vet .
-	cd irc/utils && go test . && go vet .
+
+test-gofmt:
 	./.check-gofmt.sh
+
+test-irc:
+	cd irc && go test . && go vet .
+
+test-%:
+	cd irc/$(patsubst test-%,%,$@) && go test . && go vet .
 
 smoke:
 	ergo mkcerts --conf ./default.yaml || true


### PR DESCRIPTION
By making each command its own target instead of running them sequentially,
'make -j' can run them in parallel.

On my (slow) machine, it makes the wall-clock time go from 20 to 5s.