### PR TITLE
fix #1980

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3358,7 +3358,7 @@ func (client *Client) rplWhoReply(channel *Channel, target *Client, rb *Response
 		if canSeeIPs || client == target {
 			// you can only see a target's IP if they're you or you're an oper
 			ip, _ := target.getWhoisActually()
-			fIP = ip.String()
+			fIP = utils.IPStringToHostname(ip.String())
 		}
 		params = append(params, fIP)
 	}


### PR DESCRIPTION
Sanitize ::1 to 0::1 in WHOX output

```
who #asdf %ai
:oragono.test 354 bsdf 0::1 0
:oragono.test 315 bsdf #asdf :End of WHO list
```