### PR TITLE
/UBAN LIST explicitly states 'indefinite' durations for Klines/Dlines 

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -897,10 +897,7 @@ func formatBanForListing(client *Client, key string, info IPBanInfo) string {
 	if info.OperReason != "" && info.OperReason != info.Reason {
 		desc = fmt.Sprintf("%s | %s", info.Reason, info.OperReason)
 	}
-	if info.Duration != 0 {
-		desc = fmt.Sprintf("%s [%s]", desc, info.TimeLeft())
-	}
-	desc = fmt.Sprintf("%s added on [%s]", desc, info.TimeCreated.UTC().Format(time.RFC1123))
+	desc = fmt.Sprintf("%s [%s] added on [%s]", desc, info.TimeLeft(), info.TimeCreated.UTC().Format(time.RFC1123))
 	banType := "Ban"
 	if info.RequireSASL {
 		banType = "SASL required"


### PR DESCRIPTION
Solves #1943 
I didn't do much except allow the condition for when `info.Duration=0` in formatban function.
I have tested it locally.