### PR TITLE
use new aligned atomic types everywhere

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -165,7 +165,7 @@ type Session struct {
 	sasl       saslStatus
 	passStatus serverPassStatus
 
-	batchCounter uint32
+	batchCounter atomic.Uint32
 
 	quitMessage string
 
@@ -262,7 +262,7 @@ func (session *Session) HasHistoryCaps() bool {
 // or nesting) on an individual session connection need to be unique.
 // this allows ~4 billion such batches which should be fine.
 func (session *Session) generateBatchID() string {
-	id := atomic.AddUint32(&session.batchCounter, 1)
+	id := session.batchCounter.Add(1)
 	return strconv.FormatInt(int64(id), 32)
 }
 

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -6,7 +6,6 @@ package irc
 import (
 	"fmt"
 	"net"
-	"sync/atomic"
 	"time"
 
 	"github.com/ergochat/ergo/irc/caps"
@@ -36,11 +35,11 @@ func (server *Server) Languages() (lm *languages.Manager) {
 }
 
 func (server *Server) Defcon() uint32 {
-	return atomic.LoadUint32(&server.defcon)
+	return server.defcon.Load()
 }
 
 func (server *Server) SetDefcon(defcon uint32) {
-	atomic.StoreUint32(&server.defcon, defcon)
+	server.defcon.Store(defcon)
 }
 
 func (client *Client) Sessions() (sessions []*Session) {

--- a/irc/server.go
+++ b/irc/server.go
@@ -91,7 +91,7 @@ type Server struct {
 	stats             Stats
 	semaphores        ServerSemaphores
 	flock             flock.Flocker
-	defcon            uint32
+	defcon            atomic.Uint32
 }
 
 // NewServer returns a new Oragono server.
@@ -103,8 +103,8 @@ func NewServer(config *Config, logger *logger.Manager) (*Server, error) {
 		logger:       logger,
 		rehashSignal: make(chan os.Signal, 1),
 		exitSignals:  make(chan os.Signal, len(utils.ServerExitSignals)),
-		defcon:       5,
 	}
+	server.defcon.Store(5)
 
 	server.accepts.Initialize()
 	server.clients.Initialize()


### PR DESCRIPTION
See 69448b13a10a14517 / #1969; the compiler can now ensure that a uint64
intended for atomic access is always aligned to a 64-bit boundary.
Convert atomic operations on uint32s and pointers as well.