### PR TITLE
exempt a configurable number of MARKREAD commands from fakelag

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -849,6 +849,14 @@ fakelag:
     # sending any commands:
     cooldown: 2s
 
+    # exempt a certain number of command invocations per session from fakelag;
+    # this is to speed up "resynchronization" of client state during reattach
+    command-budgets:
+        "CHATHISTORY": 16
+        "MARKREAD":    16
+        "MONITOR":     1
+        "WHO":         4
+
 # the roleplay commands are semi-standardized extensions to IRC that allow
 # sending and receiving messages from pseudo-nicknames. this can be used either
 # for actual roleplaying, or for bridging IRC with other protocols.

--- a/irc/config.go
+++ b/irc/config.go
@@ -524,6 +524,7 @@ type FakelagConfig struct {
 	BurstLimit        uint `yaml:"burst-limit"`
 	MessagesPerWindow uint `yaml:"messages-per-window"`
 	Cooldown          time.Duration
+	CommandBudgets    map[string]int `yaml:"command-budgets"`
 }
 
 type TorListenersConfig struct {
@@ -1427,6 +1428,17 @@ func LoadConfig(filename string) (config *Config, err error) {
 		return nil, fmt.Errorf("Could not load languages: %s", err.Error())
 	}
 	config.Server.capValues[caps.Languages] = config.languageManager.CapValue()
+
+	if len(config.Fakelag.CommandBudgets) != 0 {
+		// normalize command names to uppercase:
+		commandBudgets := make(map[string]int, len(config.Fakelag.CommandBudgets))
+		for command, budget := range config.Fakelag.CommandBudgets {
+			commandBudgets[strings.ToUpper(command)] = budget
+		}
+		config.Fakelag.CommandBudgets = commandBudgets
+	} else {
+		config.Fakelag.CommandBudgets = nil
+	}
 
 	if config.Server.Relaymsg.Enabled {
 		for _, char := range protocolBreakingNameCharacters {

--- a/irc/fakelag_test.go
+++ b/irc/fakelag_test.go
@@ -60,7 +60,7 @@ func TestFakelag(t *testing.T) {
 	window, _ := time.ParseDuration("1s")
 	fl, mt := newFakelagForTesting(window, 3, 2, window)
 
-	fl.Touch()
+	fl.Touch("")
 	slept, _ := mt.lastSleep()
 	if slept {
 		t.Fatalf("should not have slept")
@@ -69,7 +69,7 @@ func TestFakelag(t *testing.T) {
 	interval, _ := time.ParseDuration("100ms")
 	for i := 0; i < 2; i++ {
 		mt.pause(interval)
-		fl.Touch()
+		fl.Touch("")
 		slept, _ := mt.lastSleep()
 		if slept {
 			t.Fatalf("should not have slept")
@@ -77,7 +77,7 @@ func TestFakelag(t *testing.T) {
 	}
 
 	mt.pause(interval)
-	fl.Touch()
+	fl.Touch("")
 	if fl.state != FakelagThrottled {
 		t.Fatalf("should be throttled")
 	}
@@ -91,7 +91,7 @@ func TestFakelag(t *testing.T) {
 	}
 
 	// send another message without a pause; we should have to sleep for 500 msec
-	fl.Touch()
+	fl.Touch("")
 	if fl.state != FakelagThrottled {
 		t.Fatalf("should be throttled")
 	}
@@ -102,7 +102,7 @@ func TestFakelag(t *testing.T) {
 	}
 
 	mt.pause(interval * 6)
-	fl.Touch()
+	fl.Touch("")
 	if fl.state != FakelagThrottled {
 		t.Fatalf("should still be throttled")
 	}
@@ -112,7 +112,7 @@ func TestFakelag(t *testing.T) {
 	}
 
 	mt.pause(window * 2)
-	fl.Touch()
+	fl.Touch("")
 	if fl.state != FakelagBursting {
 		t.Fatalf("should be bursting again")
 	}

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -821,6 +821,14 @@ fakelag:
     # sending any commands:
     cooldown: 2s
 
+    # exempt a certain number of command invocations per session from fakelag;
+    # this is to speed up "resynchronization" of client state during reattach
+    command-budgets:
+        "CHATHISTORY": 16
+        "MARKREAD":    16
+        "MONITOR":     1
+        "WHO":         4
+
 # the roleplay commands are semi-standardized extensions to IRC that allow
 # sending and receiving messages from pseudo-nicknames. this can be used either
 # for actual roleplaying, or for bridging IRC with other protocols.


### PR DESCRIPTION
This is #1978. I merged instead of squashing so I forced master to undo it (naughty).