### PR TITLE
fix #1996

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -449,10 +449,10 @@ func awayHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 	var isAway bool
 	var awayMessage string
 	if len(msg.Params) > 0 {
-		isAway = true
 		awayMessage = msg.Params[0]
 		awayMessage = ircutils.TruncateUTF8Safe(awayMessage, server.Config().Limits.AwayLen)
 	}
+	isAway = (awayMessage != "") // #1996
 
 	rb.session.SetAway(awayMessage)
 


### PR DESCRIPTION
According to the de facto standard, `AWAY :\r\n` is equivalent to `AWAY\r\n`. Our behavior was inconsistent before, now it consistently matches the de facto standard.