### PR TITLE
fix #1975

### DIFF
--- a/irc/utils/signals.go
+++ b/irc/utils/signals.go
@@ -18,4 +18,8 @@ var (
 		syscall.SIGTERM,
 		syscall.SIGQUIT,
 	}
+
+	ServerTracebackSignals = []os.Signal{
+		syscall.SIGUSR1,
+	}
 )

--- a/irc/utils/signals_plan9.go
+++ b/irc/utils/signals_plan9.go
@@ -18,4 +18,7 @@ var (
 		syscall.SIGINT,
 		syscall.SIGTERM,
 	}
+
+	// no SIGUSR1 on plan9
+	ServerTracebackSignals []os.Signal
 )


### PR DESCRIPTION
Provide a nondestructive stack trace dump option even when the http pprof listener is disabled