### PR TITLE
change default casefolding to ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,20 @@ If you want to take a look at a running Ergo instance or test some client code, 
 
 * integrated services: NickServ for user accounts, ChanServ for channel registration, and HostServ for vanity hosts
 * bouncer-like features: storing and replaying history, allowing multiple clients to use the same nickname
-* UTF-8 nick and channel names with rfc7613 (PRECIS)
 * native TLS/SSL support, including support for client certificates
+* [IRCv3 support](https://ircv3.net/software/servers.html)
 * [yaml](https://yaml.org/) configuration
 * updating server config and TLS certificates on-the-fly (rehashing)
 * SASL authentication
 * [LDAP support](https://github.com/ergochat/ergo-ldap)
 * supports [multiple languages](https://crowdin.com/project/ergochat) (you can also set a default language for your network)
+* optional support for UTF-8 nick and channel names with RFC 8265 (PRECIS)
 * advanced security and privacy features (support for requiring SASL for all logins, cloaking IPs, and running as a Tor hidden service)
 * an extensible privilege system for IRC operators
 * ident lookups for usernames
 * automated client connection limits
 * passwords stored with [bcrypt](https://godoc.org/golang.org/x/crypto)
 * `UBAN`, a unified ban system that can target IPs, networks, masks, and registered accounts (`KLINE` and `DLINE` are also supported)
-* [IRCv3 support](https://ircv3.net/software/servers.html)
 * a focus on developing with [specifications](https://ergo.chat/specs.html)
 
 For more detailed information on Ergo's functionality, see:

--- a/default.yaml
+++ b/default.yaml
@@ -131,15 +131,15 @@ server:
 
     # casemapping controls what kinds of strings are permitted as identifiers (nicknames,
     # channel names, account names, etc.), and how they are normalized for case.
-    # with the recommended default of 'precis', UTF8 identifiers that are "sane"
-    # (according to RFC 8265) are allowed, and the server additionally tries to protect
-    # against confusable characters ("homoglyph attacks").
-    # the other options are 'ascii' (traditional ASCII-only identifiers), and 'permissive',
-    # which allows identifiers to contain unusual characters like emoji, but makes users
-    # vulnerable to homoglyph attacks. unless you're really confident in your decision,
-    # we recommend leaving this value at its default (changing it once the network is
-    # already up and running is problematic).
-    casemapping: "precis"
+    # the recommended default is 'ascii' (traditional ASCII-only identifiers).
+    # the other options are 'precis', which allows UTF8 identifiers that are "sane"
+    # (according to UFC 8265), with additional mitigations for homoglyph attacks,
+    # and 'permissive', which allows identifiers containing unusual characters like
+    # emoji, at the cost of increased vulnerability to homoglyph attacks and potential
+    # client compatibility problems. we recommend leaving this value at its default;
+    # however, note that changing it once the network is already up and running is
+    # problematic.
+    casemapping: "ascii"
 
     # enforce-utf8 controls whether the server will preemptively discard non-UTF8
     # messages (since they cannot be relayed to websocket clients), or will allow

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -105,15 +105,15 @@ server:
 
     # casemapping controls what kinds of strings are permitted as identifiers (nicknames,
     # channel names, account names, etc.), and how they are normalized for case.
-    # with the recommended default of 'precis', UTF8 identifiers that are "sane"
-    # (according to RFC 8265) are allowed, and the server additionally tries to protect
-    # against confusable characters ("homoglyph attacks").
-    # the other options are 'ascii' (traditional ASCII-only identifiers), and 'permissive',
-    # which allows identifiers to contain unusual characters like emoji, but makes users
-    # vulnerable to homoglyph attacks. unless you're really confident in your decision,
-    # we recommend leaving this value at its default (changing it once the network is
-    # already up and running is problematic).
-    casemapping: "precis"
+    # the recommended default is 'ascii' (traditional ASCII-only identifiers).
+    # the other options are 'precis', which allows UTF8 identifiers that are "sane"
+    # (according to UFC 8265), with additional mitigations for homoglyph attacks,
+    # and 'permissive', which allows identifiers containing unusual characters like
+    # emoji, at the cost of increased vulnerability to homoglyph attacks and potential
+    # client compatibility problems. we recommend leaving this value at its default;
+    # however, note that changing it once the network is already up and running is
+    # problematic.
+    casemapping: "ascii"
 
     # enforce-utf8 controls whether the server will preemptively discard non-UTF8
     # messages (since they cannot be relayed to websocket clients), or will allow


### PR DESCRIPTION
See discussion on #1718.

I want to do this in the 2.11 bugfix release unless there is strong pushback. PRECIS will remain fully supported, it just won't be the recommended default anymore.