### PR TITLE
don't reference SIGUSR1 on windows

### DIFF
--- a/irc/utils/signals_plan9.go
+++ b/irc/utils/signals_plan9.go
@@ -1,5 +1,4 @@
 //go:build plan9
-// +build plan9
 
 // Copyright (c) 2020 Shivaram Lingamneni
 // released under the MIT license

--- a/irc/utils/signals_windows.go
+++ b/irc/utils/signals_windows.go
@@ -1,4 +1,4 @@
-//go:build !plan9 && !windows
+//go:build windows
 
 // Copyright (c) 2020 Shivaram Lingamneni
 // released under the MIT license
@@ -18,7 +18,6 @@ var (
 		syscall.SIGQUIT,
 	}
 
-	ServerTracebackSignals = []os.Signal{
-		syscall.SIGUSR1,
-	}
+	// no SIGUSR1 on windows
+	ServerTracebackSignals []os.Signal
 )


### PR DESCRIPTION
This is a bug from #2014 that was breaking compilation for Windows.