### PR TITLE
Fix SAREGISTER short help in SAVERIFY command

### DIFF
--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -174,7 +174,7 @@ an administrator can set use this command to set up user accounts.`,
 			help: `Syntax: $bSAVERIFY <username>$b
 
 SAVERIFY manually verifies an account that is pending verification.`,
-			helpShort: `$bSAREGISTER$b registers an account on someone else's behalf.`,
+			helpShort: `$bSAVERIFY$b manually verifies an account that is pending verification.`,
 			enabled:   servCmdRequiresAuthEnabled, // deliberate
 			capabs:    []string{"accreg"},
 			minParams: 1,


### PR DESCRIPTION
Currently the `SAREGISTER` command short help appears twice in `/ns help`, and `SAVERIFY` is not listed. Short help is copy-pasted from long help.