### PR TITLE
Fix #2023 (disable dynamic linking by default)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null)
 GIT_TAG := $(shell git tag --points-at HEAD 2> /dev/null | head -n 1)
 
+# disable linking against native libc / libpthread by default;
+# this can be overridden by passing CGO_ENABLED=1 to make
+export CGO_ENABLED ?= 0
+
 capdef_file = ./irc/caps/defs.go
 
 all: install


### PR DESCRIPTION
Disable dynamic linking by default. We have the whole release cycle to evaluate whether this causes problems (I don't anticipate any).