### PR TITLE
disable cgo for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,8 @@
 project_name: ergo
 builds:
   - main: ergo.go
+    env:
+      - CGO_ENABLED=0
     binary: ergo
     goos:
       - linux


### PR DESCRIPTION
Follows up from #2025. Fixes:

```
   ⨯ release failed after 5.75s error=failed to build for darwin_arm64: exit status 2: # runtime/cgo
gcc: error: unrecognized command-line option '-arch'
```

with goreleaser 1.0.0 and go 1.19.4.