### PR TITLE
refactor of channel persistence to use UUIDs

### DIFF
--- a/irc/bunt/bunt_datastore.go
+++ b/irc/bunt/bunt_datastore.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 Shivaram Lingamneni
+// released under the MIT license
+
+package bunt
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tidwall/buntdb"
+
+	"github.com/ergochat/ergo/irc/datastore"
+	"github.com/ergochat/ergo/irc/logger"
+	"github.com/ergochat/ergo/irc/utils"
+)
+
+// BuntKey yields a string key corresponding to a (table, UUID) pair.
+// Ideally this would not be public, but some of the migration code
+// needs it.
+func BuntKey(table datastore.Table, uuid utils.UUID) string {
+	return fmt.Sprintf("%x %s", table, uuid.String())
+}
+
+// buntdbDatastore implements datastore.Datastore using a buntdb.
+type buntdbDatastore struct {
+	db     *buntdb.DB
+	logger *logger.Manager
+}
+
+// NewBuntdbDatastore returns a datastore.Datastore backed by buntdb.
+func NewBuntdbDatastore(db *buntdb.DB, logger *logger.Manager) datastore.Datastore {
+	return &buntdbDatastore{
+		db:     db,
+		logger: logger,
+	}
+}
+
+func (b *buntdbDatastore) Backoff() time.Duration {
+	return 0
+}
+
+func (b *buntdbDatastore) GetAll(table datastore.Table) (result []datastore.KV, err error) {
+	tablePrefix := fmt.Sprintf("%x ", table)
+	err = b.db.View(func(tx *buntdb.Tx) error {
+		err := tx.AscendGreaterOrEqual("", tablePrefix, func(key, value string) bool {
+			if !strings.HasPrefix(key, tablePrefix) {
+				return false
+			}
+			uuid, err := utils.DecodeUUID(strings.TrimPrefix(key, tablePrefix))
+			if err == nil {
+				result = append(result, datastore.KV{UUID: uuid, Value: []byte(value)})
+			} else {
+				b.logger.Error("datastore", "invalid uuid", key)
+			}
+			return true
+		})
+		return err
+	})
+	return
+}
+
+func (b *buntdbDatastore) Get(table datastore.Table, uuid utils.UUID) (value []byte, err error) {
+	buntKey := BuntKey(table, uuid)
+	var result string
+	err = b.db.View(func(tx *buntdb.Tx) error {
+		result, err = tx.Get(buntKey)
+		return err
+	})
+	return []byte(result), err
+}
+
+func (b *buntdbDatastore) Set(table datastore.Table, uuid utils.UUID, value []byte, expiration time.Time) (err error) {
+	buntKey := BuntKey(table, uuid)
+	var setOptions *buntdb.SetOptions
+	if !expiration.IsZero() {
+		ttl := time.Until(expiration)
+		if ttl > 0 {
+			setOptions = &buntdb.SetOptions{Expires: true, TTL: ttl}
+		} else {
+			return nil // it already expired, i guess?
+		}
+	}
+	strVal := string(value)
+
+	err = b.db.Update(func(tx *buntdb.Tx) error {
+		_, _, err := tx.Set(buntKey, strVal, setOptions)
+		return err
+	})
+	return
+}
+
+func (b *buntdbDatastore) Delete(table datastore.Table, key utils.UUID) (err error) {
+	buntKey := BuntKey(table, key)
+	err = b.db.Update(func(tx *buntdb.Tx) error {
+		_, err := tx.Delete(buntKey)
+		return err
+	})
+	// deleting a nonexistent key is not considered an error
+	switch err {
+	case buntdb.ErrNotFound:
+		return nil
+	default:
+		return err
+	}
+}

--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -5,12 +5,7 @@ package irc
 
 import (
 	"encoding/json"
-	"fmt"
-	"strconv"
-	"strings"
 	"time"
-
-	"github.com/tidwall/buntdb"
 
 	"github.com/ergochat/ergo/irc/modes"
 	"github.com/ergochat/ergo/irc/utils"
@@ -18,48 +13,6 @@ import (
 
 // this is exclusively the *persistence* layer for channel registration;
 // channel creation/tracking/destruction is in channelmanager.go
-
-const (
-	keyChannelExists         = "channel.exists %s"
-	keyChannelName           = "channel.name %s" // stores the 'preferred name' of the channel, not casemapped
-	keyChannelRegTime        = "channel.registered.time %s"
-	keyChannelFounder        = "channel.founder %s"
-	keyChannelTopic          = "channel.topic %s"
-	keyChannelTopicSetBy     = "channel.topic.setby %s"
-	keyChannelTopicSetTime   = "channel.topic.settime %s"
-	keyChannelBanlist        = "channel.banlist %s"
-	keyChannelExceptlist     = "channel.exceptlist %s"
-	keyChannelInvitelist     = "channel.invitelist %s"
-	keyChannelPassword       = "channel.key %s"
-	keyChannelModes          = "channel.modes %s"
-	keyChannelAccountToUMode = "channel.accounttoumode %s"
-	keyChannelUserLimit      = "channel.userlimit %s"
-	keyChannelSettings       = "channel.settings %s"
-	keyChannelForward        = "channel.forward %s"
-
-	keyChannelPurged = "channel.purged %s"
-)
-
-var (
-	channelKeyStrings = []string{
-		keyChannelExists,
-		keyChannelName,
-		keyChannelRegTime,
-		keyChannelFounder,
-		keyChannelTopic,
-		keyChannelTopicSetBy,
-		keyChannelTopicSetTime,
-		keyChannelBanlist,
-		keyChannelExceptlist,
-		keyChannelInvitelist,
-		keyChannelPassword,
-		keyChannelModes,
-		keyChannelAccountToUMode,
-		keyChannelUserLimit,
-		keyChannelSettings,
-		keyChannelForward,
-	}
-)
 
 // these are bit flags indicating what part of the channel status is "dirty"
 // and needs to be read from memory and written to the db
@@ -80,8 +33,8 @@ const (
 type RegisteredChannel struct {
 	// Name of the channel.
 	Name string
-	// Casefolded name of the channel.
-	NameCasefolded string
+	// UUID for the datastore.
+	UUID utils.UUID
 	// RegisteredAt represents the time that the channel was registered.
 	RegisteredAt time.Time
 	// Founder indicates the founder of the channel.
@@ -112,322 +65,26 @@ type RegisteredChannel struct {
 	Settings ChannelSettings
 }
 
+func (r *RegisteredChannel) Serialize() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+func (r *RegisteredChannel) Deserialize(b []byte) (err error) {
+	return json.Unmarshal(b, r)
+}
+
 type ChannelPurgeRecord struct {
-	Oper     string
-	PurgedAt time.Time
-	Reason   string
+	NameCasefolded string `json:"Name"`
+	UUID           utils.UUID
+	Oper           string
+	PurgedAt       time.Time
+	Reason         string
 }
 
-// ChannelRegistry manages registered channels.
-type ChannelRegistry struct {
-	server *Server
+func (c *ChannelPurgeRecord) Serialize() ([]byte, error) {
+	return json.Marshal(c)
 }
 
-// NewChannelRegistry returns a new ChannelRegistry.
-func (reg *ChannelRegistry) Initialize(server *Server) {
-	reg.server = server
-}
-
-// AllChannels returns the uncasefolded names of all registered channels.
-func (reg *ChannelRegistry) AllChannels() (result []string) {
-	prefix := fmt.Sprintf(keyChannelName, "")
-	reg.server.store.View(func(tx *buntdb.Tx) error {
-		return tx.AscendGreaterOrEqual("", prefix, func(key, value string) bool {
-			if !strings.HasPrefix(key, prefix) {
-				return false
-			}
-			result = append(result, value)
-			return true
-		})
-	})
-
-	return
-}
-
-// PurgedChannels returns the set of all casefolded channel names that have been purged
-func (reg *ChannelRegistry) PurgedChannels() (result utils.HashSet[string]) {
-	result = make(utils.HashSet[string])
-
-	prefix := fmt.Sprintf(keyChannelPurged, "")
-	reg.server.store.View(func(tx *buntdb.Tx) error {
-		return tx.AscendGreaterOrEqual("", prefix, func(key, value string) bool {
-			if !strings.HasPrefix(key, prefix) {
-				return false
-			}
-			channel := strings.TrimPrefix(key, prefix)
-			result.Add(channel)
-			return true
-		})
-	})
-	return
-}
-
-// StoreChannel obtains a consistent view of a channel, then persists it to the store.
-func (reg *ChannelRegistry) StoreChannel(info RegisteredChannel, includeFlags uint) (err error) {
-	if !reg.server.ChannelRegistrationEnabled() {
-		return
-	}
-
-	if info.Founder == "" {
-		// sanity check, don't try to store an unregistered channel
-		return
-	}
-
-	reg.server.store.Update(func(tx *buntdb.Tx) error {
-		reg.saveChannel(tx, info, includeFlags)
-		return nil
-	})
-
-	return nil
-}
-
-// LoadChannel loads a channel from the store.
-func (reg *ChannelRegistry) LoadChannel(nameCasefolded string) (info RegisteredChannel, err error) {
-	if !reg.server.ChannelRegistrationEnabled() {
-		err = errFeatureDisabled
-		return
-	}
-
-	channelKey := nameCasefolded
-	// nice to have: do all JSON (de)serialization outside of the buntdb transaction
-	err = reg.server.store.View(func(tx *buntdb.Tx) error {
-		_, dberr := tx.Get(fmt.Sprintf(keyChannelExists, channelKey))
-		if dberr == buntdb.ErrNotFound {
-			// chan does not already exist, return
-			return errNoSuchChannel
-		}
-
-		// channel exists, load it
-		name, _ := tx.Get(fmt.Sprintf(keyChannelName, channelKey))
-		regTime, _ := tx.Get(fmt.Sprintf(keyChannelRegTime, channelKey))
-		regTimeInt, _ := strconv.ParseInt(regTime, 10, 64)
-		founder, _ := tx.Get(fmt.Sprintf(keyChannelFounder, channelKey))
-		topic, _ := tx.Get(fmt.Sprintf(keyChannelTopic, channelKey))
-		topicSetBy, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetBy, channelKey))
-		var topicSetTime time.Time
-		topicSetTimeStr, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetTime, channelKey))
-		if topicSetTimeInt, topicSetTimeErr := strconv.ParseInt(topicSetTimeStr, 10, 64); topicSetTimeErr == nil {
-			topicSetTime = time.Unix(0, topicSetTimeInt).UTC()
-		}
-		password, _ := tx.Get(fmt.Sprintf(keyChannelPassword, channelKey))
-		modeString, _ := tx.Get(fmt.Sprintf(keyChannelModes, channelKey))
-		userLimitString, _ := tx.Get(fmt.Sprintf(keyChannelUserLimit, channelKey))
-		forward, _ := tx.Get(fmt.Sprintf(keyChannelForward, channelKey))
-		banlistString, _ := tx.Get(fmt.Sprintf(keyChannelBanlist, channelKey))
-		exceptlistString, _ := tx.Get(fmt.Sprintf(keyChannelExceptlist, channelKey))
-		invitelistString, _ := tx.Get(fmt.Sprintf(keyChannelInvitelist, channelKey))
-		accountToUModeString, _ := tx.Get(fmt.Sprintf(keyChannelAccountToUMode, channelKey))
-		settingsString, _ := tx.Get(fmt.Sprintf(keyChannelSettings, channelKey))
-
-		modeSlice := make([]modes.Mode, len(modeString))
-		for i, mode := range modeString {
-			modeSlice[i] = modes.Mode(mode)
-		}
-
-		userLimit, _ := strconv.Atoi(userLimitString)
-
-		var banlist map[string]MaskInfo
-		_ = json.Unmarshal([]byte(banlistString), &banlist)
-		var exceptlist map[string]MaskInfo
-		_ = json.Unmarshal([]byte(exceptlistString), &exceptlist)
-		var invitelist map[string]MaskInfo
-		_ = json.Unmarshal([]byte(invitelistString), &invitelist)
-		accountToUMode := make(map[string]modes.Mode)
-		_ = json.Unmarshal([]byte(accountToUModeString), &accountToUMode)
-
-		var settings ChannelSettings
-		_ = json.Unmarshal([]byte(settingsString), &settings)
-
-		info = RegisteredChannel{
-			Name:           name,
-			NameCasefolded: nameCasefolded,
-			RegisteredAt:   time.Unix(0, regTimeInt).UTC(),
-			Founder:        founder,
-			Topic:          topic,
-			TopicSetBy:     topicSetBy,
-			TopicSetTime:   topicSetTime,
-			Key:            password,
-			Modes:          modeSlice,
-			Bans:           banlist,
-			Excepts:        exceptlist,
-			Invites:        invitelist,
-			AccountToUMode: accountToUMode,
-			UserLimit:      int(userLimit),
-			Settings:       settings,
-			Forward:        forward,
-		}
-		return nil
-	})
-
-	return
-}
-
-// Delete deletes a channel corresponding to `info`. If no such channel
-// is present in the database, no error is returned.
-func (reg *ChannelRegistry) Delete(info RegisteredChannel) (err error) {
-	if !reg.server.ChannelRegistrationEnabled() {
-		return
-	}
-
-	reg.server.store.Update(func(tx *buntdb.Tx) error {
-		reg.deleteChannel(tx, info.NameCasefolded, info)
-		return nil
-	})
-	return nil
-}
-
-// delete a channel, unless it was overwritten by another registration of the same channel
-func (reg *ChannelRegistry) deleteChannel(tx *buntdb.Tx, key string, info RegisteredChannel) {
-	_, err := tx.Get(fmt.Sprintf(keyChannelExists, key))
-	if err == nil {
-		regTime, _ := tx.Get(fmt.Sprintf(keyChannelRegTime, key))
-		regTimeInt, _ := strconv.ParseInt(regTime, 10, 64)
-		registeredAt := time.Unix(0, regTimeInt).UTC()
-		founder, _ := tx.Get(fmt.Sprintf(keyChannelFounder, key))
-
-		// to see if we're deleting the right channel, confirm the founder and the registration time
-		if founder == info.Founder && registeredAt.Equal(info.RegisteredAt) {
-			for _, keyFmt := range channelKeyStrings {
-				tx.Delete(fmt.Sprintf(keyFmt, key))
-			}
-
-			// remove this channel from the client's list of registered channels
-			channelsKey := fmt.Sprintf(keyAccountChannels, info.Founder)
-			channelsStr, err := tx.Get(channelsKey)
-			if err == buntdb.ErrNotFound {
-				return
-			}
-			registeredChannels := unmarshalRegisteredChannels(channelsStr)
-			var nowRegisteredChannels []string
-			for _, channel := range registeredChannels {
-				if channel != key {
-					nowRegisteredChannels = append(nowRegisteredChannels, channel)
-				}
-			}
-			tx.Set(channelsKey, strings.Join(nowRegisteredChannels, ","), nil)
-		}
-	}
-}
-
-func (reg *ChannelRegistry) updateAccountToChannelMapping(tx *buntdb.Tx, channelInfo RegisteredChannel) {
-	channelKey := channelInfo.NameCasefolded
-	chanFounderKey := fmt.Sprintf(keyChannelFounder, channelKey)
-	founder, existsErr := tx.Get(chanFounderKey)
-	if existsErr == buntdb.ErrNotFound || founder != channelInfo.Founder {
-		// add to new founder's list
-		accountChannelsKey := fmt.Sprintf(keyAccountChannels, channelInfo.Founder)
-		alreadyChannels, _ := tx.Get(accountChannelsKey)
-		newChannels := channelKey // this is the casefolded channel name
-		if alreadyChannels != "" {
-			newChannels = fmt.Sprintf("%s,%s", alreadyChannels, newChannels)
-		}
-		tx.Set(accountChannelsKey, newChannels, nil)
-	}
-	if existsErr == nil && founder != channelInfo.Founder {
-		// remove from old founder's list
-		accountChannelsKey := fmt.Sprintf(keyAccountChannels, founder)
-		alreadyChannelsRaw, _ := tx.Get(accountChannelsKey)
-		var newChannels []string
-		if alreadyChannelsRaw != "" {
-			for _, chname := range strings.Split(alreadyChannelsRaw, ",") {
-				if chname != channelInfo.NameCasefolded {
-					newChannels = append(newChannels, chname)
-				}
-			}
-		}
-		tx.Set(accountChannelsKey, strings.Join(newChannels, ","), nil)
-	}
-}
-
-// saveChannel saves a channel to the store.
-func (reg *ChannelRegistry) saveChannel(tx *buntdb.Tx, channelInfo RegisteredChannel, includeFlags uint) {
-	channelKey := channelInfo.NameCasefolded
-	// maintain the mapping of account -> registered channels
-	reg.updateAccountToChannelMapping(tx, channelInfo)
-
-	if includeFlags&IncludeInitial != 0 {
-		tx.Set(fmt.Sprintf(keyChannelExists, channelKey), "1", nil)
-		tx.Set(fmt.Sprintf(keyChannelName, channelKey), channelInfo.Name, nil)
-		tx.Set(fmt.Sprintf(keyChannelRegTime, channelKey), strconv.FormatInt(channelInfo.RegisteredAt.UnixNano(), 10), nil)
-		tx.Set(fmt.Sprintf(keyChannelFounder, channelKey), channelInfo.Founder, nil)
-	}
-
-	if includeFlags&IncludeTopic != 0 {
-		tx.Set(fmt.Sprintf(keyChannelTopic, channelKey), channelInfo.Topic, nil)
-		var topicSetTimeStr string
-		if !channelInfo.TopicSetTime.IsZero() {
-			topicSetTimeStr = strconv.FormatInt(channelInfo.TopicSetTime.UnixNano(), 10)
-		}
-		tx.Set(fmt.Sprintf(keyChannelTopicSetTime, channelKey), topicSetTimeStr, nil)
-		tx.Set(fmt.Sprintf(keyChannelTopicSetBy, channelKey), channelInfo.TopicSetBy, nil)
-	}
-
-	if includeFlags&IncludeModes != 0 {
-		tx.Set(fmt.Sprintf(keyChannelPassword, channelKey), channelInfo.Key, nil)
-		modeString := modes.Modes(channelInfo.Modes).String()
-		tx.Set(fmt.Sprintf(keyChannelModes, channelKey), modeString, nil)
-		tx.Set(fmt.Sprintf(keyChannelUserLimit, channelKey), strconv.Itoa(channelInfo.UserLimit), nil)
-		tx.Set(fmt.Sprintf(keyChannelForward, channelKey), channelInfo.Forward, nil)
-	}
-
-	if includeFlags&IncludeLists != 0 {
-		banlistString, _ := json.Marshal(channelInfo.Bans)
-		tx.Set(fmt.Sprintf(keyChannelBanlist, channelKey), string(banlistString), nil)
-		exceptlistString, _ := json.Marshal(channelInfo.Excepts)
-		tx.Set(fmt.Sprintf(keyChannelExceptlist, channelKey), string(exceptlistString), nil)
-		invitelistString, _ := json.Marshal(channelInfo.Invites)
-		tx.Set(fmt.Sprintf(keyChannelInvitelist, channelKey), string(invitelistString), nil)
-		accountToUModeString, _ := json.Marshal(channelInfo.AccountToUMode)
-		tx.Set(fmt.Sprintf(keyChannelAccountToUMode, channelKey), string(accountToUModeString), nil)
-	}
-
-	if includeFlags&IncludeSettings != 0 {
-		settingsString, _ := json.Marshal(channelInfo.Settings)
-		tx.Set(fmt.Sprintf(keyChannelSettings, channelKey), string(settingsString), nil)
-	}
-}
-
-// PurgeChannel records a channel purge.
-func (reg *ChannelRegistry) PurgeChannel(chname string, record ChannelPurgeRecord) (err error) {
-	serialized, err := json.Marshal(record)
-	if err != nil {
-		return err
-	}
-	serializedStr := string(serialized)
-	key := fmt.Sprintf(keyChannelPurged, chname)
-
-	return reg.server.store.Update(func(tx *buntdb.Tx) error {
-		tx.Set(key, serializedStr, nil)
-		return nil
-	})
-}
-
-// LoadPurgeRecord retrieves information about whether and how a channel was purged.
-func (reg *ChannelRegistry) LoadPurgeRecord(chname string) (record ChannelPurgeRecord, err error) {
-	var rawRecord string
-	key := fmt.Sprintf(keyChannelPurged, chname)
-	reg.server.store.View(func(tx *buntdb.Tx) error {
-		rawRecord, _ = tx.Get(key)
-		return nil
-	})
-	if rawRecord == "" {
-		err = errNoSuchChannel
-		return
-	}
-	err = json.Unmarshal([]byte(rawRecord), &record)
-	if err != nil {
-		reg.server.logger.Error("internal", "corrupt purge record", chname, err.Error())
-		err = errNoSuchChannel
-		return
-	}
-	return
-}
-
-// UnpurgeChannel deletes the record of a channel purge.
-func (reg *ChannelRegistry) UnpurgeChannel(chname string) (err error) {
-	key := fmt.Sprintf(keyChannelPurged, chname)
-	return reg.server.store.Update(func(tx *buntdb.Tx) error {
-		tx.Delete(key)
-		return nil
-	})
+func (c *ChannelPurgeRecord) Deserialize(b []byte) error {
+	return json.Unmarshal(b, c)
 }

--- a/irc/datastore/datastore.go
+++ b/irc/datastore/datastore.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package datastore
+
+import (
+	"time"
+
+	"github.com/ergochat/ergo/irc/utils"
+)
+
+type Table uint16
+
+// XXX these are persisted and must remain stable;
+// do not reorder, when deleting use _ to ensure that the deleted value is skipped
+const (
+	TableMetadata Table = iota
+	TableChannels
+	TableChannelPurges
+)
+
+type KV struct {
+	UUID  utils.UUID
+	Value []byte
+}
+
+// A Datastore provides the following abstraction:
+// 1. Tables, each keyed on a UUID (the implementation is free to merge
+// the table name and the UUID into a single key as long as the rest of
+// the contract can be satisfied). Table names are [a-z0-9_]+
+// 2. The ability to efficiently enumerate all uuid-value pairs in a table
+// 3. Gets, sets, and deletes for individual (table, uuid) keys
+type Datastore interface {
+	Backoff() time.Duration
+
+	GetAll(table Table) ([]KV, error)
+
+	// This is rarely used because it would typically lead to TOCTOU races
+	Get(table Table, key utils.UUID) (value []byte, err error)
+
+	Set(table Table, key utils.UUID, value []byte, expiration time.Time) error
+
+	// Note that deleting a nonexistent key is not considered an error
+	Delete(table Table, key utils.UUID) error
+}

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -51,6 +51,7 @@ var (
 	errNoExistingBan                  = errors.New("Ban does not exist")
 	errNoSuchChannel                  = errors.New(`No such channel`)
 	errChannelPurged                  = errors.New(`This channel was purged by the server operators and cannot be used`)
+	errChannelPurgedAlready           = errors.New(`This channel was already purged and cannot be purged again`)
 	errConfusableIdentifier           = errors.New("This identifier is confusable with one already in use")
 	errInsufficientPrivs              = errors.New("Insufficient privileges")
 	errInvalidUsername                = errors.New("Invalid username")

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -638,3 +638,9 @@ func (channel *Channel) getAmode(cfaccount string) (result modes.Mode) {
 	defer channel.stateMutex.RUnlock()
 	return channel.accountToUMode[cfaccount]
 }
+
+func (channel *Channel) UUID() utils.UUID {
+	channel.stateMutex.RLock()
+	defer channel.stateMutex.RUnlock()
+	return channel.uuid
+}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1718,7 +1718,7 @@ func listHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 
 	clientIsOp := client.HasRoleCapabs("sajoin")
 	if len(channels) == 0 {
-		for _, channel := range server.channels.Channels() {
+		for _, channel := range server.channels.ListableChannels() {
 			if !clientIsOp && channel.flags.HasMode(modes.Secret) && !channel.hasClient(client) {
 				continue
 			}

--- a/irc/hostserv.go
+++ b/irc/hostserv.go
@@ -193,6 +193,6 @@ func hsSetCloakSecretHandler(service *ircService, server *Server, client *Client
 		service.Notice(rb, fmt.Sprintf(client.t("To confirm, run this command: %s"), fmt.Sprintf("/HS SETCLOAKSECRET %s %s", secret, expectedCode)))
 		return
 	}
-	StoreCloakSecret(server.store, secret)
+	StoreCloakSecret(server.dstore, secret)
 	service.Notice(rb, client.t("Rotated the cloak secret; you must rehash or restart the server for it to take effect"))
 }

--- a/irc/legacy.go
+++ b/irc/legacy.go
@@ -4,7 +4,15 @@ package irc
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/tidwall/buntdb"
+
+	"github.com/ergochat/ergo/irc/modes"
 )
 
 var (
@@ -24,4 +32,117 @@ func decodeLegacyPasswordHash(hash string) ([]byte, error) {
 	} else {
 		return nil, errInvalidPasswordHash
 	}
+}
+
+// legacy channel registration code
+
+const (
+	keyChannelExists         = "channel.exists %s"
+	keyChannelName           = "channel.name %s" // stores the 'preferred name' of the channel, not casemapped
+	keyChannelRegTime        = "channel.registered.time %s"
+	keyChannelFounder        = "channel.founder %s"
+	keyChannelTopic          = "channel.topic %s"
+	keyChannelTopicSetBy     = "channel.topic.setby %s"
+	keyChannelTopicSetTime   = "channel.topic.settime %s"
+	keyChannelBanlist        = "channel.banlist %s"
+	keyChannelExceptlist     = "channel.exceptlist %s"
+	keyChannelInvitelist     = "channel.invitelist %s"
+	keyChannelPassword       = "channel.key %s"
+	keyChannelModes          = "channel.modes %s"
+	keyChannelAccountToUMode = "channel.accounttoumode %s"
+	keyChannelUserLimit      = "channel.userlimit %s"
+	keyChannelSettings       = "channel.settings %s"
+	keyChannelForward        = "channel.forward %s"
+
+	keyChannelPurged = "channel.purged %s"
+)
+
+func deleteLegacyChannel(tx *buntdb.Tx, nameCasefolded string) {
+	tx.Delete(fmt.Sprintf(keyChannelExists, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelName, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelRegTime, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelFounder, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelTopic, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelTopicSetBy, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelTopicSetTime, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelBanlist, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelExceptlist, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelInvitelist, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelPassword, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelModes, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelAccountToUMode, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelUserLimit, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelSettings, nameCasefolded))
+	tx.Delete(fmt.Sprintf(keyChannelForward, nameCasefolded))
+}
+
+func loadLegacyChannel(tx *buntdb.Tx, nameCasefolded string) (info RegisteredChannel, err error) {
+	channelKey := nameCasefolded
+	// nice to have: do all JSON (de)serialization outside of the buntdb transaction
+	_, dberr := tx.Get(fmt.Sprintf(keyChannelExists, channelKey))
+	if dberr == buntdb.ErrNotFound {
+		// chan does not already exist, return
+		err = errNoSuchChannel
+		return
+	}
+
+	// channel exists, load it
+	name, _ := tx.Get(fmt.Sprintf(keyChannelName, channelKey))
+	regTime, _ := tx.Get(fmt.Sprintf(keyChannelRegTime, channelKey))
+	regTimeInt, _ := strconv.ParseInt(regTime, 10, 64)
+	founder, _ := tx.Get(fmt.Sprintf(keyChannelFounder, channelKey))
+	topic, _ := tx.Get(fmt.Sprintf(keyChannelTopic, channelKey))
+	topicSetBy, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetBy, channelKey))
+	var topicSetTime time.Time
+	topicSetTimeStr, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetTime, channelKey))
+	if topicSetTimeInt, topicSetTimeErr := strconv.ParseInt(topicSetTimeStr, 10, 64); topicSetTimeErr == nil {
+		topicSetTime = time.Unix(0, topicSetTimeInt).UTC()
+	}
+	password, _ := tx.Get(fmt.Sprintf(keyChannelPassword, channelKey))
+	modeString, _ := tx.Get(fmt.Sprintf(keyChannelModes, channelKey))
+	userLimitString, _ := tx.Get(fmt.Sprintf(keyChannelUserLimit, channelKey))
+	forward, _ := tx.Get(fmt.Sprintf(keyChannelForward, channelKey))
+	banlistString, _ := tx.Get(fmt.Sprintf(keyChannelBanlist, channelKey))
+	exceptlistString, _ := tx.Get(fmt.Sprintf(keyChannelExceptlist, channelKey))
+	invitelistString, _ := tx.Get(fmt.Sprintf(keyChannelInvitelist, channelKey))
+	accountToUModeString, _ := tx.Get(fmt.Sprintf(keyChannelAccountToUMode, channelKey))
+	settingsString, _ := tx.Get(fmt.Sprintf(keyChannelSettings, channelKey))
+
+	modeSlice := make([]modes.Mode, len(modeString))
+	for i, mode := range modeString {
+		modeSlice[i] = modes.Mode(mode)
+	}
+
+	userLimit, _ := strconv.Atoi(userLimitString)
+
+	var banlist map[string]MaskInfo
+	_ = json.Unmarshal([]byte(banlistString), &banlist)
+	var exceptlist map[string]MaskInfo
+	_ = json.Unmarshal([]byte(exceptlistString), &exceptlist)
+	var invitelist map[string]MaskInfo
+	_ = json.Unmarshal([]byte(invitelistString), &invitelist)
+	accountToUMode := make(map[string]modes.Mode)
+	_ = json.Unmarshal([]byte(accountToUModeString), &accountToUMode)
+
+	var settings ChannelSettings
+	_ = json.Unmarshal([]byte(settingsString), &settings)
+
+	info = RegisteredChannel{
+		Name:           name,
+		RegisteredAt:   time.Unix(0, regTimeInt).UTC(),
+		Founder:        founder,
+		Topic:          topic,
+		TopicSetBy:     topicSetBy,
+		TopicSetTime:   topicSetTime,
+		Key:            password,
+		Modes:          modeSlice,
+		Bans:           banlist,
+		Excepts:        exceptlist,
+		Invites:        invitelist,
+		AccountToUMode: accountToUMode,
+		UserLimit:      int(userLimit),
+		Settings:       settings,
+		Forward:        forward,
+	}
+	return info, nil
 }

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -954,9 +954,9 @@ func nsInfoHandler(service *ircService, server *Server, client *Client, command 
 
 func listRegisteredChannels(service *ircService, accountName string, rb *ResponseBuffer) {
 	client := rb.session.client
-	channels := client.server.accounts.ChannelsForAccount(accountName)
+	channels := client.server.channels.ChannelsForAccount(accountName)
 	service.Notice(rb, fmt.Sprintf(client.t("Account %s has %d registered channel(s)."), accountName, len(channels)))
-	for _, channel := range rb.session.client.server.accounts.ChannelsForAccount(accountName) {
+	for _, channel := range channels {
 		service.Notice(rb, fmt.Sprintf(client.t("Registered channel: %s"), channel))
 	}
 }

--- a/irc/serde.go
+++ b/irc/serde.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Shivaram Lingamneni
+// released under the MIT license
+
+package irc
+
+import (
+	"strconv"
+
+	"github.com/ergochat/ergo/irc/datastore"
+	"github.com/ergochat/ergo/irc/logger"
+)
+
+type Serializable interface {
+	Serialize() ([]byte, error)
+	Deserialize([]byte) error
+}
+
+func FetchAndDeserializeAll[T any, C interface {
+	*T
+	Serializable
+}](table datastore.Table, dstore datastore.Datastore, log *logger.Manager) (result []T, err error) {
+	rawRecords, err := dstore.GetAll(table)
+	if err != nil {
+		return
+	}
+	result = make([]T, len(rawRecords))
+	pos := 0
+	for _, record := range rawRecords {
+		err := C(&result[pos]).Deserialize(record.Value)
+		if err != nil {
+			log.Error("internal", "deserialization error", strconv.Itoa(int(table)), record.UUID.String(), err.Error())
+			continue
+		}
+		pos++
+	}
+	return result[:pos], nil
+}

--- a/irc/utils/uuid.go
+++ b/irc/utils/uuid.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+)
+
+var (
+	ErrInvalidUUID = errors.New("Invalid uuid")
+)
+
+// Technically a UUIDv4 has version bits set, but this doesn't matter in practice
+type UUID [16]byte
+
+func (u UUID) MarshalJSON() (b []byte, err error) {
+	b = make([]byte, 24)
+	b[0] = '"'
+	base64.RawURLEncoding.Encode(b[1:], u[:])
+	b[23] = '"'
+	return
+}
+
+func (u *UUID) UnmarshalJSON(b []byte) (err error) {
+	if len(b) != 24 {
+		return ErrInvalidUUID
+	}
+	readLen, err := base64.RawURLEncoding.Decode(u[:], b[1:23])
+	if readLen != 16 {
+		return ErrInvalidUUID
+	}
+	return nil
+}
+
+func (u *UUID) String() string {
+	return base64.RawURLEncoding.EncodeToString(u[:])
+}
+
+func GenerateUUIDv4() (result UUID) {
+	_, err := rand.Read(result[:])
+	if err != nil {
+		panic(err)
+	}
+	return
+}
+
+func DecodeUUID(ustr string) (result UUID, err error) {
+	length, err := base64.RawURLEncoding.Decode(result[:], []byte(ustr))
+	if err == nil && length != 16 {
+		err = ErrInvalidUUID
+	}
+	return
+}


### PR DESCRIPTION
This is pretty complicated and touches a lot of things, so I'm interested in reviews, maybe from @ajaspers or @progval ?

The core idea here is to refactor persistence to eventually support datastores other than buntdb. There are two problems:

1. We don't want typical chat operations to block on the datastore (this is mostly implemented already, with the asynchronous persistence / `markDirty` stuff, but there are some cases where we would still block, particularly for accounts where every login currently incurs a read from the datastore)
2. We don't want to require nontrivial consistency guarantees from the datastore

The new approach is best illustrated by the new, weak datastore API:

https://github.com/slingamn/ergo/blob/7ce06362764ee35629521eacc1fdee5405370efd/irc/datastore/datastore.go

which exposes key-value pairs. Each key has a UUID and is associated with a "table". There are four operations:

1. Read everything from a table. This is used at ircd startup to read all persisted data. The source of truth then becomes the in-memory datastructures, with asynchronous persistence back to the datastore
2. Set a key, with an optional TTL that will be respected by the datastore
3. Delete a key
4. Read a single key (this is used for some edge cases, like schema changes)

This branch refactors channels and channel purge records to use the new API.