### PR TITLE
recommended default: advertise SCRAM

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -450,6 +450,10 @@ accounts:
     # this is useful for compatibility with old clients that don't support SASL
     login-via-pass-command: true
 
+    # advertise the SCRAM-SHA-256 authentication method. set to false in case of
+    # compatibility issues with certain clients:
+    advertise-scram: true
+
     # require-sasl controls whether clients are required to have accounts
     # (and sign into them using SASL) to connect to the server
     require-sasl:

--- a/irc/config.go
+++ b/irc/config.go
@@ -303,7 +303,7 @@ func (t *ThrottleConfig) UnmarshalYAML(unmarshal func(interface{}) error) (err e
 type AccountConfig struct {
 	Registration          AccountRegistrationConfig
 	AuthenticationEnabled bool `yaml:"authentication-enabled"`
-	AdvertiseSCRAM        bool `yaml:"advertise-scram"` // undocumented, see #1782
+	AdvertiseSCRAM        bool `yaml:"advertise-scram"`
 	RequireSasl           struct {
 		Enabled      bool
 		Exempted     []string
@@ -1390,7 +1390,6 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 
 	saslCapValue := "PLAIN,EXTERNAL,SCRAM-SHA-256"
-	// TODO(#1782) clean this up:
 	if !config.Accounts.AdvertiseSCRAM {
 		saslCapValue = "PLAIN,EXTERNAL"
 	}

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -423,6 +423,10 @@ accounts:
     # this is useful for compatibility with old clients that don't support SASL
     login-via-pass-command: false
 
+    # advertise the SCRAM-SHA-256 authentication method. set to false in case of
+    # compatibility issues with certain clients:
+    advertise-scram: true
+
     # require-sasl controls whether clients are required to have accounts
     # (and sign into them using SASL) to connect to the server
     require-sasl:


### PR DESCRIPTION
cc @jwheare

IRCCloud attempts SCRAM-SHA-256 when it is advertised and does not fall back to PLAIN on failure. This will break authentication for accounts that were created on Ergo 2.7 or earlier, then never logged into again until the first time SCRAM-SHA-256 was advertised (because we only have bcrypt-based credentials and no SCRAM credentials). This is an unacceptable compatibility break, but it's also a weird enough edge case that IRCCloud will probably never fix it.

Compromise: make advertising it a recommended default, but require old servers to opt in explicitly. On a related note, [SCRAM is bad and clients should not implement it](https://gist.github.com/slingamn/3f2fed196df5ef14d1316a1ffa9d59f8).

Fixes #1782