### PR TITLE
fix #2031

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2887,7 +2887,7 @@ func rehashHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 		// TODO all operators should get a notice of some kind here
 		rb.Notice(client.t("Rehash complete"))
 	} else {
-		rb.Add(nil, server.name, ERR_UNKNOWNERROR, nick, "REHASH", err.Error())
+		rb.Add(nil, server.name, ERR_UNKNOWNERROR, nick, "REHASH", ircutils.SanitizeText(err.Error(), 350))
 	}
 	return false
 }


### PR DESCRIPTION
Sanitize the in-band error message from REHASH

Example of the fixed output: `:oragono.test 400 netcat REHASH :yaml: unmarshal errors:    line 594: cannot unmarshal !!map into []logger.LoggingConfig`

Replacing `400 ERR_UNKNOWNERROR` with `FAIL` isn't such a good idea after all. `FAIL` requires a code and we don't have one specified for this case (or most of the other cases where we currently send a 400). A code of `*` would probably work but needs some discussion.