### PR TITLE
bump github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: "checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "setup go"
-        uses: "actions/setup-go@v2"
+        uses: "actions/setup-go@v3"
         with:
           go-version: "1.19"
       - name: "install python3-pytest"


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/