### PR TITLE
pointfix for websocket client DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to Ergo will be documented in this file.
 
+## [2.11.1] - 2022-01-22
+
+Ergo 2.11.1 is a bugfix release, fixing a denial-of-service issue in our websocket implementation. We regret the oversight.
+
+This release includes no changes to the config file format or database file format.
+
+### Security
+* Fixed a denial-of-service issue affecting websocket clients (#2039)
+
 ## [2.11.0] - 2022-12-25
 
 We're pleased to be publishing v2.11.0, a new stable release. This is another bugfix release aimed at improving client compatibility and keeping up with the IRCv3 specification process.

--- a/irc/ircconn.go
+++ b/irc/ircconn.go
@@ -128,9 +128,9 @@ func (wc IRCWSConn) WriteLines(buffers [][]byte) (err error) {
 }
 
 func (wc IRCWSConn) ReadLine() (line []byte, err error) {
-	messageType, line, err := wc.conn.ReadMessage()
+	_, line, err = wc.conn.ReadMessage()
 	if err == nil {
-		if messageType == websocket.BinaryMessage && !utf8.Valid(line) {
+		if !utf8.Valid(line) {
 			return line, errInvalidUtf8
 		}
 		return line, nil

--- a/irc/version.go
+++ b/irc/version.go
@@ -7,7 +7,7 @@ import "fmt"
 
 const (
 	// SemVer is the semantic version of Ergo.
-	SemVer = "2.11.0"
+	SemVer = "2.11.1"
 )
 
 var (


### PR DESCRIPTION
I assumed gorilla validated UTF8 for incoming text messages. In fact, the
documentation states:

>It is the application's responsibility to ensure that text messages
>are valid UTF-8 encoded text.

and this applies to both incoming and outgoing messages. Consequently,
even when enforce-utf8 is enabled, it was possible to send invalid UTF8
to Ergo inside a websocket text frame. This data would be incorrectly
considered valid UTF8, and could be relayed to other clients, including
to websocket clients inside a text frame. The resulting frame would violate
the websocket protocol, causing web clients to be disconnected.