### PR TITLE
irc/utils: ErrInvalidUUID improve error message

### DIFF
--- a/irc/utils/uuid_test.go
+++ b/irc/utils/uuid_test.go
@@ -1,0 +1,12 @@
+package utils
+
+import "testing"
+
+func TestErrInvalidUUID(t *testing.T) {
+	bad := []byte("abcd")
+	want := `Invalid uuid:"abcd"`
+	got := ErrInvalidUUID{bad}.Error()
+	if want != got {
+		t.Fatalf("want:%q got:%q", want, got)
+	}
+}


### PR DESCRIPTION
The `err` variable on line 31 was being semi-dropped in the case that the call to `Decode()` returned both an error and a length of 16.

I refactored `ErrInvalidUUID` a little bit so that an operator will see an error message that includes the invalid UUID causing the problem. I added `TestErrInvalidUUID()` to verify that it is returning the format that I expected.