### PR TITLE
Implement draft/message-redaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,19 @@ capdef_file = ./irc/caps/defs.go
 
 all: build
 
-install:
+install: build
 	go install -v -ldflags "-X main.commit=$(GIT_COMMIT) -X main.version=$(GIT_TAG)"
 
-build:
+build: ${capdef_file}
 	go build -v -ldflags "-X main.commit=$(GIT_COMMIT) -X main.version=$(GIT_TAG)"
 
-release:
+release: build
 	goreleaser --skip-publish --rm-dist
 
-capdefs:
+${capdef_file}: ./gencapdefs.py
 	python3 ./gencapdefs.py > ${capdef_file}
 
-test:
+test: ${capdef_file}
 	python3 ./gencapdefs.py | diff - ${capdef_file}
 	go test ./...
 	go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,19 @@ capdef_file = ./irc/caps/defs.go
 
 all: build
 
-install: build
+install:
 	go install -v -ldflags "-X main.commit=$(GIT_COMMIT) -X main.version=$(GIT_TAG)"
 
-build: ${capdef_file}
+build:
 	go build -v -ldflags "-X main.commit=$(GIT_COMMIT) -X main.version=$(GIT_TAG)"
 
-release: build
+release:
 	goreleaser --skip-publish --rm-dist
 
-${capdef_file}: ./gencapdefs.py
+capdefs:
 	python3 ./gencapdefs.py > ${capdef_file}
 
-test: ${capdef_file}
+test:
 	python3 ./gencapdefs.py | diff - ${capdef_file}
 	go test ./...
 	go vet ./...

--- a/default.yaml
+++ b/default.yaml
@@ -982,7 +982,8 @@ history:
 
     # options to control how messages are stored and deleted:
     retention:
-        # allow users to delete their own messages from history?
+        # allow users to delete their own messages from history,
+        # and channel operators to delete messages in their channel?
         allow-individual-delete: false
 
         # if persistent history is enabled, create additional index tables,

--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -88,6 +88,12 @@ CAPDEFS = [
         standard="proposed IRCv3",
     ),
     CapDef(
+        identifier="MessageRedaction",
+        name="draft/message-redaction",
+        url="https://github.com/progval/ircv3-specifications/blob/redaction/extensions/message-redaction.md",
+        standard="proposed IRCv3",
+    ),
+    CapDef(
         identifier="MessageTags",
         name="message-tags",
         url="https://ircv3.net/specs/extensions/message-tags.html",

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -7,9 +7,9 @@ package caps
 
 const (
 	// number of recognized capabilities:
-	numCapabs = 32
+	numCapabs = 33
 	// length of the uint32 array that represents the bitset:
-	bitsetLen = 1
+	bitsetLen = 2
 )
 
 const (
@@ -56,6 +56,10 @@ const (
 	// Languages is the proposed IRCv3 capability named "draft/languages":
 	// https://gist.github.com/DanielOaks/8126122f74b26012a3de37db80e4e0c6
 	Languages Capability = iota
+
+	// MessageRedaction is the proposed IRCv3 capability named "draft/message-redaction":
+	// https://github.com/progval/ircv3-specifications/blob/redaction/extensions/message-redaction.md
+	MessageRedaction Capability = iota
 
 	// Multiline is the proposed IRCv3 capability named "draft/multiline":
 	// https://github.com/ircv3/ircv3-specifications/pull/398
@@ -156,6 +160,7 @@ var (
 		"draft/chathistory",
 		"draft/event-playback",
 		"draft/languages",
+		"draft/message-redaction",
 		"draft/multiline",
 		"draft/persistence",
 		"draft/pre-away",

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -301,6 +301,10 @@ func init() {
 			usablePreReg: true,
 			minParams:    0,
 		},
+		"REDACT": {
+			handler:   redactHandler,
+			minParams: 2,
+		},
 		"REHASH": {
 			handler:   rehashHandler,
 			minParams: 0,

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2701,8 +2701,8 @@ func redactHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 
 		err := server.DeleteMessage(target, targetmsgid, accountName)
 		if err == errNoop {
-			// Chat history is disabled; but this shouldn't be an error because we
-			// are going to relay the REDACT to other clients
+			rb.Add(nil, server.name, "FAIL", "REDACT", "UNKNOWN_MSGID", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("This message does not exist or is too old"))
+			return false
 		} else if err != nil {
 			isOper := client.HasRoleCapabs("history")
 			if isOper || true{

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2672,6 +2672,8 @@ func redactHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 	if len(msg.Params) > 2 {
 		reason = msg.Params[2]
 	}
+	var members []*Client // members of a channel, or both parties of a PM
+	var canDelete CanDelete
 
 	msgid := utils.GenerateSecretToken()
 	time := time.Now().UTC().Round(0)
@@ -2684,46 +2686,69 @@ func redactHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 			rb.Add(nil, server.name, ERR_NOSUCHCHANNEL, client.Nick(), utils.SafeErrorParam(target), client.t("No such channel"))
 			return false
 		}
-
-		canDelete := canDelete(server, client, target)
-		if canDelete == canDeleteNone {
-			rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("You are not authorized to delete messages"))
+		members = channel.Members()
+		canDelete = deletionPolicy(server, client, target)
+	} else {
+		targetClient := server.clients.Get(target)
+		if targetClient == nil {
+			rb.Add(nil, server.name, ERR_NOSUCHNICK, client.Nick(), target, "No such nick")
 			return false
 		}
-		accountName := "*"
-		if canDelete == canDeleteSelf {
-			accountName = client.AccountName()
-			if accountName == "*" {
-				rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("You are not authorized to delete because you are logged out"))
-				return false
-			}
-		}
+		members = []*Client{client, targetClient}
+		canDelete = canDeleteSelf
+	}
 
-		err := server.DeleteMessage(target, targetmsgid, accountName)
-		if err == errNoop {
-			rb.Add(nil, server.name, "FAIL", "REDACT", "UNKNOWN_MSGID", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("This message does not exist or is too old"))
+	if canDelete == canDeleteNone {
+		rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("You are not authorized to delete messages"))
+		return false
+	}
+	accountName := "*"
+	if canDelete == canDeleteSelf {
+		accountName = client.AccountName()
+		if accountName == "*" {
+			rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("You are not authorized to delete because you are logged out"))
 			return false
-		} else if err != nil {
+		}
+	}
+
+	err := server.DeleteMessage(target, targetmsgid, accountName)
+	if err == errNoop {
+		rb.Add(nil, server.name, "FAIL", "REDACT", "UNKNOWN_MSGID", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("This message does not exist or is too old"))
+		return false
+	} else if err != nil {
+		isOper := client.HasRoleCapabs("history")
+		if isOper {
+			rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), fmt.Sprintf(client.t("Error deleting message: %v"), err))
+		} else {
+			rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("Could not delete message"))
+		}
+		return false
+	}
+
+	if target[0] != '#' {
+		// If this is a PM, we just removed the message from the buffer of the other party;
+		// now we have to remove it from the buffer of the client who sent the REDACT command
+		err := server.DeleteMessage(client.Nick(), targetmsgid, accountName)
+
+		if err != nil {
+			client.server.logger.Error("internal", fmt.Sprintf("Private message %s is not deletable by %s from their own buffer's even though we just deleted it from %s's. This is a bug, please report it in details.", targetmsgid, client.Nick(), target), client.Nick())
 			isOper := client.HasRoleCapabs("history")
-			if isOper || true {
+			if isOper {
 				rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), fmt.Sprintf(client.t("Error deleting message: %v"), err))
 			} else {
-				rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("Could not delete message"))
+				rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("Error deleting message"))
 			}
-			return false
 		}
+	}
 
-		for _, member := range channel.Members() {
-			for _, session := range member.Sessions() {
-				if session.capabilities.Has(caps.MessageRedaction) {
-					session.sendFromClientInternal(false, time, msgid, details.nickMask, details.accountName, isBot, nil, "REDACT", target, targetmsgid, reason)
-				} else {
-					// TODO: add configurable fallback
-				}
+	for _, member := range members {
+		for _, session := range member.Sessions() {
+			if session.capabilities.Has(caps.MessageRedaction) {
+				session.sendFromClientInternal(false, time, msgid, details.nickMask, details.accountName, isBot, nil, "REDACT", target, targetmsgid, reason)
+			} else {
+				// TODO: add configurable fallback
 			}
 		}
-	} else {
-		// TODO
 	}
 	return false
 }

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2665,8 +2665,8 @@ fail:
 
 // REDACT <target> <targetmsgid> [:<reason>]
 func redactHandler(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
-	target := msg.Params[0];
-	targetmsgid := msg.Params[1];
+	target := msg.Params[0]
+	targetmsgid := msg.Params[1]
 	//clientOnlyTags := msg.ClientOnlyTags()
 	var reason string
 	if len(msg.Params) > 2 {
@@ -2705,7 +2705,7 @@ func redactHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 			return false
 		} else if err != nil {
 			isOper := client.HasRoleCapabs("history")
-			if isOper || true{
+			if isOper || true {
 				rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), fmt.Sprintf(client.t("Error deleting message: %v"), err))
 			} else {
 				rb.Add(nil, server.name, "FAIL", "REDACT", "REDACT_FORBIDDEN", utils.SafeErrorParam(target), utils.SafeErrorParam(targetmsgid), client.t("Could not delete message"))

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2746,7 +2746,8 @@ func redactHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 			if session.capabilities.Has(caps.MessageRedaction) {
 				session.sendFromClientInternal(false, time, msgid, details.nickMask, details.accountName, isBot, nil, "REDACT", target, targetmsgid, reason)
 			} else {
-				// TODO: add configurable fallback
+				// If we wanted to send a fallback to clients which do not support
+				// draft/message-redaction, we would do it from here.
 			}
 		}
 	}

--- a/irc/help.go
+++ b/irc/help.go
@@ -436,6 +436,12 @@ Replies to a PING. Used to check link connectivity.`,
 
 Sends the text to the given targets as a PRIVMSG.`,
 	},
+	"redact": {
+		text: `REDACT <target> <targetmsgid> [<reason>]
+
+Removes the message of the target msgid from the chat history of a channel
+or target user.`,
+	},
 	"relaymsg": {
 		text: `RELAYMSG <channel> <spoofed nick> :<message>
 

--- a/irc/histserv.go
+++ b/irc/histserv.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-    canDeleteAny = iota  // User is allowed to delete any message (for a given channel/PM)
-    canDeleteSelf  // User is allowed to delete their own messages (ditto)
-    canDeleteNone  // User is not allowed to delete any message (ditto)
+	canDeleteAny  = iota // User is allowed to delete any message (for a given channel/PM)
+	canDeleteSelf        // User is allowed to delete their own messages (ditto)
+	canDeleteNone        // User is not allowed to delete any message (ditto)
 )
 
 const (
@@ -101,25 +101,26 @@ func histservForgetHandler(service *ircService, server *Server, client *Client, 
 // Returns:
 //
 // 1. `canDeleteAny` if the client allowed to delete other users' messages from the target, ie.:
-//    * the client is a channel operator, or
-//    * the client is an operator with "history" capability
+//   - the client is a channel operator, or
+//   - the client is an operator with "history" capability
+//
 // 2. `canDeleteSelf` if the client is allowed to delete their own messages from the target
 // 3. `canDeleteNone` otherwise
 func canDelete(server *Server, client *Client, target string) int {
 	isOper := client.HasRoleCapabs("history")
 	if isOper {
-        return canDeleteAny
-    } else {
+		return canDeleteAny
+	} else {
 		if server.Config().History.Retention.AllowIndividualDelete {
 			channel := server.channels.Get(target)
 			if channel != nil && channel.ClientIsAtLeast(client, modes.Operator) {
 				return canDeleteAny
 			} else {
-                return canDeleteSelf
+				return canDeleteSelf
 			}
 		} else {
-            return canDeleteNone
-        }
+			return canDeleteNone
+		}
 	}
 }
 

--- a/irc/histserv.go
+++ b/irc/histserv.go
@@ -18,9 +18,9 @@ import (
 type CanDelete uint
 
 const (
-	canDeleteAny CanDelete = iota // User is allowed to delete any message (for a given channel/PM)
-	canDeleteSelf                 // User is allowed to delete their own messages (ditto)
-	canDeleteNone                 // User is not allowed to delete any message (ditto)
+	canDeleteAny  CanDelete = iota // User is allowed to delete any message (for a given channel/PM)
+	canDeleteSelf                  // User is allowed to delete their own messages (ditto)
+	canDeleteNone                  // User is not allowed to delete any message (ditto)
 )
 
 const (

--- a/irc/histserv.go
+++ b/irc/histserv.go
@@ -108,7 +108,7 @@ func histservForgetHandler(service *ircService, server *Server, client *Client, 
 //
 // 2. `canDeleteSelf` if the client is allowed to delete their own messages from the target
 // 3. `canDeleteNone` otherwise
-func canDelete(server *Server, client *Client, target string) CanDelete {
+func deletionPolicy(server *Server, client *Client, target string) CanDelete {
 	isOper := client.HasRoleCapabs("history")
 	if isOper {
 		return canDeleteAny
@@ -129,7 +129,7 @@ func canDelete(server *Server, client *Client, target string) CanDelete {
 func histservDeleteHandler(service *ircService, server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
 	target, msgid := params[0], params[1] // Fix #1881 2 params are required
 
-	canDelete := canDelete(server, client, target)
+	canDelete := deletionPolicy(server, client, target)
 	accountName := "*"
 	if canDelete == canDeleteNone {
 		service.Notice(rb, client.t("Insufficient privileges"))

--- a/irc/histserv.go
+++ b/irc/histserv.go
@@ -15,10 +15,12 @@ import (
 	"github.com/ergochat/ergo/irc/utils"
 )
 
+type CanDelete uint
+
 const (
-	canDeleteAny  = iota // User is allowed to delete any message (for a given channel/PM)
-	canDeleteSelf        // User is allowed to delete their own messages (ditto)
-	canDeleteNone        // User is not allowed to delete any message (ditto)
+	canDeleteAny CanDelete = iota // User is allowed to delete any message (for a given channel/PM)
+	canDeleteSelf                 // User is allowed to delete their own messages (ditto)
+	canDeleteNone                 // User is not allowed to delete any message (ditto)
 )
 
 const (
@@ -106,7 +108,7 @@ func histservForgetHandler(service *ircService, server *Server, client *Client, 
 //
 // 2. `canDeleteSelf` if the client is allowed to delete their own messages from the target
 // 3. `canDeleteNone` otherwise
-func canDelete(server *Server, client *Client, target string) int {
+func canDelete(server *Server, client *Client, target string) CanDelete {
 	isOper := client.HasRoleCapabs("history")
 	if isOper {
 		return canDeleteAny

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -954,7 +954,8 @@ history:
 
     # options to control how messages are stored and deleted:
     retention:
-        # allow users to delete their own messages from history?
+        # allow users to delete their own messages from history,
+        # and channel operators to delete messages in their channel?
         allow-individual-delete: false
 
         # if persistent history is enabled, create additional index tables,


### PR DESCRIPTION
Permission to use REDACT mirrors permission for 'HistServ DELETE'

Spec: https://github.com/ircv3/ircv3-specifications/pull/524 (this is a variant of https://github.com/ircv3/ircv3-specifications/pull/425 with only deletion/redaction, and targetmsg moved from a tag to a parameter)

Tests: https://github.com/progval/irctest/pull/203

@slingamn Thoughts on this design before I add support for PMs?