### PR TITLE
fix #2066

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -655,8 +655,10 @@ func chathistoryHandler(server *Server, client *Client, msg ircmsg.Message, rb *
 		} else {
 			// successful responses are sent as a chathistory or history batch
 			if listTargets {
-				batchID := rb.StartNestedBatch("draft/chathistory-targets")
-				defer rb.EndNestedBatch(batchID)
+				if rb.session.capabilities.Has(caps.Batch) { // #2066
+					batchID := rb.StartNestedBatch("draft/chathistory-targets")
+					defer rb.EndNestedBatch(batchID)
+				}
 				for _, target := range targets {
 					name := server.UnfoldName(target.CfName)
 					rb.Add(nil, server.name, "CHATHISTORY", "TARGETS", name,


### PR DESCRIPTION
CHATHISTORY TARGETS response should not be in a batch unless the client has explicitly requested the batch cap.