### PR TITLE
don't send multiline responses to CAP LS 301

### DIFF
--- a/irc/caps/set.go
+++ b/irc/caps/set.go
@@ -106,7 +106,7 @@ func (s *Set) Strings(version Version, values Values, maxLen int) (result []stri
 		// responses. omit some CAPs in this case, forcing the response to fit on
 		// a single line. this is technically buggy for CAP LIST (as opposed to LS)
 		// but it shouldn't matter
-		if version < Cap302 && isRareCapability(capab) {
+		if version < Cap302 && !isAllowed301(capab) {
 			continue
 		}
 		// skip any capabilities that are not enabled
@@ -130,11 +130,12 @@ func (s *Set) Strings(version Version, values Values, maxLen int) (result []stri
 	return
 }
 
-func isRareCapability(capab Capability) bool {
+// this is a fixed whitelist of caps that are eligible for display in CAP LS 301
+func isAllowed301(capab Capability) bool {
 	switch capab {
-	case ReadMarker, Persistence, Languages, MessageRedaction, AccountRegistration,
-		ChannelRename, Preaway, Multiline:
-		// these are drafts that legacy clients won't know about
+	case AccountNotify, AccountTag, AwayNotify, Batch, ChgHost, Chathistory, EventPlayback,
+		Relaymsg, EchoMessage, Nope, ExtendedJoin, InviteNotify, LabeledResponse, MessageTags,
+		MultiPrefix, SASL, ServerTime, SetName, STS, UserhostInNames, ZNCSelfMessage, ZNCPlayback:
 		return true
 	default:
 		return false

--- a/irc/caps/set_test.go
+++ b/irc/caps/set_test.go
@@ -3,8 +3,11 @@
 
 package caps
 
-import "testing"
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
 
 func TestSets(t *testing.T) {
 	s1 := NewSet()
@@ -58,6 +61,19 @@ func TestSets(t *testing.T) {
 	if !reflect.DeepEqual(actualCap302ValuesString, expectedCap302ValuesString) {
 		t.Errorf("Generated Cap302 values string [%s] did not match expected values string [%s]", actualCap302ValuesString, expectedCap302ValuesString)
 	}
+}
+
+func assertEqual(found, expected interface{}) {
+	if !reflect.DeepEqual(found, expected) {
+		panic(fmt.Sprintf("found %#v, expected %#v", found, expected))
+	}
+}
+
+func Test301WhitelistNotRespectedFor302(t *testing.T) {
+	s1 := NewSet()
+	s1.Enable(AccountTag, EchoMessage, StandardReplies)
+	assertEqual(s1.Strings(Cap301, nil, 0), []string{"account-tag echo-message"})
+	assertEqual(s1.Strings(Cap302, nil, 0), []string{"account-tag echo-message standard-replies"})
 }
 
 func TestSubtract(t *testing.T) {


### PR DESCRIPTION
This is more or less explicitly prohibited by the spec:

https://ircv3.net/specs/extensions/capability-negotiation.html#multiline-replies-to-cap-ls-and-cap-list

See https://github.com/progval/irctest/pull/205 ; #2065 here caused the CAP LS 301 response to spill onto two lines, breaking SASL in irssi and possibly other clients.