### PR TITLE
Dockerfile: `apk upgrade` before `add`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ## build ergo binary
 FROM golang:1.20-alpine AS build-env
 
-RUN apk add -U --force-refresh --no-cache --purge --clean-protected -l -u make git
+RUN apk upgrade -U --force-refresh --no-cache && apk add --no-cache --purge --clean-protected -l -u make git
 
 # copy ergo source
 WORKDIR /go/src/github.com/ergochat/ergo


### PR DESCRIPTION
The base golang image ships with some packages pre-installed, but they're not necessarily the latest. If we try to add a package that (transitively) depends on one of the existing ones, it'll fail if it's expecting a newer version.

To address this, simply `apk upgrade` before trying to `apk add`.

Closes #2071