### PR TITLE
fix #2108

### DIFF
--- a/irc/email/email.go
+++ b/irc/email/email.go
@@ -193,6 +193,9 @@ func ComposeMail(config MailtoConfig, recipient, subject string) (message bytes.
 	dkimDomain := config.DKIM.Domain
 	if dkimDomain != "" {
 		fmt.Fprintf(&message, "Message-ID: <%s@%s>\r\n", utils.GenerateSecretKey(), dkimDomain)
+	} else {
+		// #2108: send Message-ID even if dkim is not enabled
+		fmt.Fprintf(&message, "Message-ID: <%s-%s>\r\n", utils.GenerateSecretKey(), config.Sender)
 	}
 	fmt.Fprintf(&message, "Date: %s\r\n", time.Now().UTC().Format(time.RFC1123Z))
 	fmt.Fprintf(&message, "Subject: %s\r\n", subject)


### PR DESCRIPTION
Send Message-ID even if DKIM is not enabled, for compatibility with Gmail:

* A workaround for Ergo 2.12.0 is to enable DKIM
* You need to enable either DKIM or SPF (preferably both) to send to Gmail anyway
* You also need forward-confirmed reverse DNS, which can be tricky for IPv6...