### PR TITLE
fix #2114

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -1568,6 +1568,10 @@ func (config *Config) isRelaymsgIdentifier(nick string) bool {
 		return false
 	}
 
+	if strings.HasPrefix(nick, "#") {
+		return false // #2114
+	}
+
 	for _, char := range config.Server.Relaymsg.Separators {
 		if strings.ContainsRune(nick, char) {
 			return true


### PR DESCRIPTION
Channels with slashes (or other relaymsg separators) in their names were being falsely detected as relaymsg identifiers.