### PR TITLE
fix #2113

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -545,11 +545,14 @@ func (channel *Channel) ClientStatus(client *Client) (present bool, joinTimeSecs
 
 // helper for persisting channel-user modes for always-on clients;
 // return the channel name and all channel-user modes for a client
-func (channel *Channel) alwaysOnStatus(client *Client) (chname string, status alwaysOnChannelStatus) {
+func (channel *Channel) alwaysOnStatus(client *Client) (ok bool, chname string, status alwaysOnChannelStatus) {
 	channel.stateMutex.RLock()
 	defer channel.stateMutex.RUnlock()
 	chname = channel.name
-	data := channel.members[client]
+	data, ok := channel.members[client]
+	if !ok {
+		return
+	}
 	status.Modes = data.modes.String()
 	status.JoinTime = data.joinTime
 	return

--- a/irc/client.go
+++ b/irc/client.go
@@ -1803,7 +1803,11 @@ func (client *Client) performWrite(additionalDirtyBits uint) {
 		channels := client.Channels()
 		channelToModes := make(map[string]alwaysOnChannelStatus, len(channels))
 		for _, channel := range channels {
-			chname, status := channel.alwaysOnStatus(client)
+			ok, chname, status := channel.alwaysOnStatus(client)
+			if !ok {
+				client.server.logger.Error("internal", "client and channel membership out of sync", chname, client.Nick())
+				continue
+			}
 			channelToModes[chname] = status
 		}
 		client.server.accounts.saveChannels(account, channelToModes)


### PR DESCRIPTION
Persisting always-on clients was panicking if client X believed it was a member of channel Y, but channel Y didn't have a record of client X.

I'm not really satisfied with the root cause analysis here, but in principle there is no overriding mutex synchronizing these states (it would probably be a global bottleneck), so these can temporarily be out of sync. (If they are out of sync, will things eventually converge?)