### PR TITLE
Gracefully handle NS cert add myself <fp>

### DIFF
--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -1398,6 +1398,11 @@ func nsCertHandler(service *ircService, server *Server, client *Client, command 
 	case "add", "del":
 		if 2 <= len(params) {
 			target, certfp = params[0], params[1]
+			if client.Account() == target {
+				// If the target is equal to the account, then the user accidentally invoked operator
+				// syntax (cert add mynick <fp>) instead of self syntax (cert add <fp>).
+				target = ""
+			}
 		} else if len(params) == 1 {
 			certfp = params[0]
 		} else if len(params) == 0 && verb == "add" && rb.session.certfp != "" {


### PR DESCRIPTION
A non-operator with the nick "mynick" attempts to register a fingerprint to their authenticated account.

`/msg NickServ cert add mynick <fingerprint>`

NickServ responds with "Insufficient privileges" because they've accidentally invoked the operator syntax (to action other accounts).

This patch allows the user to add the fingerprint if the client's account is identical to the target account.

--

Note about implementation, this does add an extra mutex lock and unlock by calling `client.Account()` vs modifying the conditional logic below, but as this is security sensitive and an infrequent operation, I took the easy route of setting the zero value on `target`.
