### PR TITLE
fix #2130

### DIFF
--- a/irc/getters.go
+++ b/irc/getters.go
@@ -19,10 +19,6 @@ func (server *Server) Config() (config *Config) {
 	return server.config.Load()
 }
 
-func (server *Server) ChannelRegistrationEnabled() bool {
-	return server.Config().Channels.Registration.Enabled
-}
-
 func (server *Server) GetOperator(name string) (oper *Oper) {
 	name, err := CasefoldName(name)
 	if err != nil {

--- a/irc/server.go
+++ b/irc/server.go
@@ -702,9 +702,6 @@ func (server *Server) applyConfig(config *Config) (err error) {
 		if !oldConfig.Accounts.NickReservation.Enabled {
 			server.accounts.buildNickToAccountIndex(config)
 		}
-		if !oldConfig.Channels.Registration.Enabled {
-			server.channels.loadRegisteredChannels(config)
-		}
 		// resize history buffers as needed
 		if config.historyChangedFrom(oldConfig) {
 			for _, channel := range server.channels.Channels() {


### PR DESCRIPTION
We load registered channels unconditionally; reloading them again on rehash is incorrect. This caused buggy behavior when channel registration was disabled in the config, but some registered channels were already loaded.