### PR TITLE
fix #2135

### DIFF
--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -43,6 +43,8 @@ func performNickChange(server *Server, client *Client, target *Client, session *
 		}
 	} else if err == errNicknameReserved {
 		if !isSanick {
+			// see #1594 for context: ERR_NICKNAMEINUSE can confuse clients if the nickname is not
+			// literally in use:
 			if !client.registered {
 				rb.Add(nil, server.name, ERR_NICKNAMEINUSE, details.nick, utils.SafeErrorParam(nickname), client.t("Nickname is reserved by a different account"))
 			}


### PR DESCRIPTION
(Not sure if we'll merge this in its current form, but throwing it up so we don't forget about it)

Handling of reserved nicknames is special-cased due to #1594, but we want to send ERR_NICKNAMEINUSE if the nickname is actually in use, since that doesn't pose any client compatibility problems.