### PR TITLE
fix #2142

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -405,6 +405,10 @@ accounts:
             sender: "admin@my.network"
             require-tls: true
             helo-domain: "my.network" # defaults to server name if unset
+            # set to `tcp4` to force sending over IPv4, `tcp6` to force IPv6:
+            # protocol: "tcp4"
+            # set to force a specific source/local IPv4 or IPv6 address:
+            # local-address: "1.2.3.4"
             # options to enable DKIM signing of outgoing emails (recommended, but
             # requires creating a DNS entry for the public key):
             # dkim:

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -378,6 +378,10 @@ accounts:
             sender: "admin@my.network"
             require-tls: true
             helo-domain: "my.network" # defaults to server name if unset
+            # set to `tcp4` to force sending over IPv4, `tcp6` to force IPv6:
+            # protocol: "tcp4"
+            # set to force a specific source/local IPv4 or IPv6 address:
+            # local-address: "1.2.3.4"
             # options to enable DKIM signing of outgoing emails (recommended, but
             # requires creating a DNS entry for the public key):
             # dkim:


### PR DESCRIPTION
Allow specifying TCP4 or TCP6 for outgoing email sending, or choosing a specific local address to send from.