### PR TITLE
add a config switch to accept hostnames from WEBIRC

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -218,6 +218,10 @@ server:
                 # - "192.168.1.1"
                 # - "192.168.10.1/24"
 
+            # whether to accept the hostname parameter on the WEBIRC line as the IRC hostname
+            # (the default/recommended Ergo configuration will use cloaks instead)
+            accept-hostname: false
+
     # maximum length of clients' sendQ in bytes
     # this should be big enough to hold bursts of channel/direct messages
     max-sendq: 96k

--- a/irc/gateways.go
+++ b/irc/gateways.go
@@ -32,6 +32,7 @@ type webircConfig struct {
 	Fingerprint    *string // legacy name for certfp, #1050
 	Certfp         string
 	Hosts          []string
+	AcceptHostname bool `yaml:"accept-hostname"`
 	allowedNets    []net.IPNet
 }
 

--- a/irc/server.go
+++ b/irc/server.go
@@ -314,9 +314,7 @@ func (server *Server) checkBanScriptExemptSASL(config *Config, session *Session)
 func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 	// XXX PROXY or WEBIRC MUST be sent as the first line of the session;
 	// if we are here at all that means we have the final value of the IP
-	if session.rawHostname == "" {
-		session.client.lookupHostname(session, false)
-	}
+	c.finalizeHostname(session)
 
 	// try to complete registration normally
 	// XXX(#1057) username can be filled in by an ident query without the client

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -192,6 +192,9 @@ server:
                 # - "192.168.1.1"
                 # - "192.168.10.1/24"
 
+            # whether to accept the hostname parameter on the WEBIRC line as the IRC hostname
+            accept-hostname: true
+
     # maximum length of clients' sendQ in bytes
     # this should be big enough to hold bursts of channel/direct messages
     max-sendq: 96k


### PR DESCRIPTION
See #1686; this allows i2pd to pass the i2p address to Ergo, which may be useful for moderation under some circumstances.