### PR TITLE
fix truncation check

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1320,16 +1320,16 @@ func (channel *Channel) SendSplitMessage(command string, minPrefixMode modes.Mod
 	isBot := client.HasMode(modes.Bot)
 	chname := channel.Name()
 
+	// STATUSMSG targets are prefixed with the supplied min-prefix, e.g., @#channel
+	if minPrefixMode != modes.Mode(0) {
+		chname = fmt.Sprintf("%s%s", modes.ChannelModePrefixes[minPrefixMode], chname)
+	}
+
 	if !client.server.Config().Server.Compatibility.allowTruncation {
 		if !validateSplitMessageLen(histType, details.nickMask, chname, message) {
 			rb.Add(nil, client.server.name, ERR_INPUTTOOLONG, details.nick, client.t("Line too long to be relayed without truncation"))
 			return
 		}
-	}
-
-	// STATUSMSG targets are prefixed with the supplied min-prefix, e.g., @#channel
-	if minPrefixMode != modes.Mode(0) {
-		chname = fmt.Sprintf("%s%s", modes.ChannelModePrefixes[minPrefixMode], chname)
 	}
 
 	if channel.flags.HasMode(modes.OpModerated) {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2184,6 +2184,7 @@ func validateLineLen(msgType history.ItemType, source, target, payload string) (
 	default:
 		return true
 	}
+	limit -= len(target)
 	limit -= len(payload)
 	return limit >= 0
 }


### PR DESCRIPTION
* The message target was not being counted :-(
* The additional character added to the target by STATUSMSG was not counted

This will break irctest, but the irctest is actually wrong: https://github.com/progval/irctest/pull/281