### PR TITLE
enable building for solaris

### DIFF
--- a/irc/flock/flock.go
+++ b/irc/flock/flock.go
@@ -1,4 +1,4 @@
-//go:build !plan9
+//go:build !(plan9 || solaris)
 
 package flock
 

--- a/irc/flock/flock_unsupported.go
+++ b/irc/flock/flock_unsupported.go
@@ -1,4 +1,4 @@
-//go:build plan9
+//go:build plan9 || solaris
 
 package flock
 


### PR DESCRIPTION
This enables cross-compilation from Linux with: `GOOS=solaris GOARCH=amd64 make build`