### PR TITLE
remove GCStats.Pause initialization

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -855,7 +855,6 @@ func debugHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respon
 	switch param {
 	case "GCSTATS":
 		stats := debug.GCStats{
-			Pause:          make([]time.Duration, 10),
 			PauseQuantiles: make([]time.Duration, 5),
 		}
 		debug.ReadGCStats(&stats)


### PR DESCRIPTION
It's too small anyway so the runtime has to reallocate it.