### PR TITLE
advertise SAFELIST

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -1656,6 +1656,7 @@ func (config *Config) generateISupport() (err error) {
 		isupport.Add("RPCHAN", "E")
 		isupport.Add("RPUSER", "E")
 	}
+	isupport.Add("SAFELIST", "")
 	isupport.Add("STATUSMSG", "~&@%+")
 	isupport.Add("TARGMAX", fmt.Sprintf("NAMES:1,LIST:1,KICK:,WHOIS:1,USERHOST:10,PRIVMSG:%s,TAGMSG:%s,NOTICE:%s,MONITOR:%d", maxTargetsString, maxTargetsString, maxTargetsString, config.Limits.MonitorEntries))
 	isupport.Add("TOPICLEN", strconv.Itoa(config.Limits.TopicLen))


### PR DESCRIPTION
https://modern.ircdocs.horse/#safelist-parameter

LIST is implemented via blocking (*ResponseBuffer).Send, so it can never exceed the sendq limit.

@delthas points out that this token is not especially useful to clients:

1. If it is not advertised, it probably means that the server is not aware of it, not that LIST is unsafe
2. It's not really actionable because the only thing the client can do is to not send LIST at all, which seems unreasonable