### PR TITLE
fix buggy persistence of push timestamps

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -1881,7 +1881,7 @@ func (client *Client) performWrite(additionalDirtyBits uint) {
 		client.server.accounts.saveRealname(account, client.realname)
 	}
 	if (dirtyBits & IncludePushSubscriptions) != 0 {
-		client.server.accounts.savePushSubscriptions(account, client.getPushSubscriptions())
+		client.server.accounts.savePushSubscriptions(account, client.getPushSubscriptions(true))
 	}
 }
 
@@ -1968,7 +1968,7 @@ func (client *Client) pushWorker() {
 	for {
 		select {
 		case msg := <-client.pushQueue.queue:
-			for _, sub := range client.getPushSubscriptions() {
+			for _, sub := range client.getPushSubscriptions(false) {
 				if !client.skipPushMessage(msg) {
 					client.sendAndTrackPush(sub.Endpoint, sub.Keys, msg, true)
 				}

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -658,10 +658,17 @@ func (client *Client) hasPushSubscriptions() bool {
 	return client.pushSubscriptionsExist.Load() != 0
 }
 
-func (client *Client) getPushSubscriptions() []storedPushSubscription {
+func (client *Client) getPushSubscriptions(refresh bool) []storedPushSubscription {
+	if refresh {
+		func() {
+			client.stateMutex.Lock()
+			defer client.stateMutex.Unlock()
+			client.rebuildPushSubscriptionCache()
+		}()
+	}
+
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
-
 	return client.cachedPushSubscriptions
 }
 

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -1683,7 +1683,7 @@ func nsPushHandler(service *ircService, server *Server, client *Client, command 
 				return
 			}
 		}
-		subscriptions := target.getPushSubscriptions()
+		subscriptions := target.getPushSubscriptions(true)
 		service.Notice(rb, fmt.Sprintf(client.t("Nickname %[1]s has %[2]d push subscription(s)"), target.Nick(), len(subscriptions)))
 		for i, subscription := range subscriptions {
 			service.Notice(rb, fmt.Sprintf(client.t("Subscription %d:"), i+1))

--- a/irc/server.go
+++ b/irc/server.go
@@ -311,7 +311,7 @@ func (server *Server) periodicPushMaintenance() {
 func (server *Server) performPushMaintenance() {
 	expiration := time.Duration(server.Config().WebPush.Expiration)
 	for _, client := range server.clients.AllWithPushSubscriptions() {
-		for _, sub := range client.getPushSubscriptions() {
+		for _, sub := range client.getPushSubscriptions(true) {
 			now := time.Now()
 			// require both periodic successful push messages and renewal of the subscription via WEBPUSH REGISTER
 			if now.Sub(sub.LastSuccess) > expiration || now.Sub(sub.LastRefresh) > expiration {


### PR DESCRIPTION
getPushSubscriptions() could have a stale view of the latest subscription renewal and successful push times. We don't want to rebuild on every renewal or every push, so add a boolean refresh argument that controls rebuilding.