### PR TITLE
fix CHATHISTORY TARGETS from MySQL backend using server local TZ

### DIFF
--- a/irc/mysql/history.go
+++ b/irc/mysql/history.go
@@ -961,7 +961,7 @@ func (mysql *MySQL) listCorrespondentsInternal(ctx context.Context, target strin
 		}
 		results = append(results, history.TargetListing{
 			CfName: correspondent,
-			Time:   time.Unix(0, nanotime),
+			Time:   time.Unix(0, nanotime).UTC(),
 		})
 	}
 
@@ -1014,7 +1014,7 @@ func (mysql *MySQL) ListChannels(cfchannels []string) (results []history.TargetL
 		}
 		results = append(results, history.TargetListing{
 			CfName: target,
-			Time:   time.Unix(0, nanotime),
+			Time:   time.Unix(0, nanotime).UTC(),
 		})
 	}
 	return


### PR DESCRIPTION
time.Unix() returns a time.Time with the Location populated to the server's timezone. Such times will format incorrectly with IRCv3TimestampFormat unless they are manually converted to UTC.