### PR TITLE
block HTTP DoS attacks

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -727,8 +727,12 @@ func (client *Client) run(session *Session) {
 			}
 			session.fakelag.Touch(command)
 		} else {
-			// DoS hardening, #505
+			if session.registrationMessages == 0 && httpVerbs.Has(msg.Command) {
+				client.Send(nil, client.server.name, ERR_UNKNOWNERROR, msg.Command, "This is not an HTTP server")
+				break
+			}
 			session.registrationMessages++
+			// DoS hardening, #505
 			if client.server.Config().Limits.RegistrationMessages < session.registrationMessages {
 				client.Send(nil, client.server.name, ERR_UNKNOWNERROR, "*", client.t("You have sent too many registration messages"))
 				break

--- a/irc/server.go
+++ b/irc/server.go
@@ -63,6 +63,8 @@ var (
 	chanTypes = "#"
 
 	throttleMessage = "You have attempted to connect too many times within a short duration. Wait a while, and you will be able to connect."
+
+	httpVerbs = utils.SetLiteral("CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE")
 )
 
 // Server is the main Oragono server.


### PR DESCRIPTION
Block uses of the JS Fetch API to send HTTP message bodies that are also valid IRC. The constraint on such messages is that they must begin with a valid HTTP verb; we can detect this and reject them immediately.