### PR TITLE
safer 005 length limits

### DIFF
--- a/irc/isupport/list.go
+++ b/irc/isupport/list.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	maxLastArgLength = 400
+	maxPayloadLength = 380
 
 	/* Modern: "As the maximum number of message parameters to any reply is 15,
 	the maximum number of RPL_ISUPPORT tokens that can be advertised is 13."
@@ -98,7 +98,7 @@ func (il *List) GetDifference(newil *List) [][]string {
 	var cache []string // Token list cache
 
 	for _, token := range outTokens {
-		if len(token)+length <= maxLastArgLength {
+		if len(token)+length <= maxPayloadLength {
 			// account for the space separating tokens
 			if len(cache) > 0 {
 				length++
@@ -107,7 +107,7 @@ func (il *List) GetDifference(newil *List) [][]string {
 			length += len(token)
 		}
 
-		if len(cache) == maxParameters || len(token)+length >= maxLastArgLength {
+		if len(cache) == maxParameters || len(token)+length >= maxPayloadLength {
 			replies = append(replies, cache)
 			cache = make([]string, 0)
 			length = 0
@@ -130,9 +130,9 @@ func validateToken(token string) error {
 		return fmt.Errorf("bad isupport token (contains forbidden octets)")
 	}
 
-	// technically a token can be maxLastArgLength if it occurs alone,
+	// technically a token can be maxPayloadLength if it occurs alone,
 	// but fail it just to be safe
-	if len(token) >= maxLastArgLength {
+	if len(token) >= maxPayloadLength {
 		return fmt.Errorf("bad isupport token (too long): `%s`", token)
 	}
 
@@ -158,7 +158,7 @@ func (il *List) RegenerateCachedReply() (err error) {
 
 	for _, token := range tokens {
 		// account for the space separating tokens
-		if len(cache) == maxParameters || (len(token)+1)+length > maxLastArgLength {
+		if len(cache) == maxParameters || (len(token)+1)+length > maxPayloadLength {
 			il.CachedReply = append(il.CachedReply, cache)
 			cache = nil
 			length = 0

--- a/irc/server.go
+++ b/irc/server.go
@@ -520,14 +520,14 @@ func (server *Server) sendRplISupportLines(client *Client, rb *ResponseBuffer, l
 		batchID := rb.StartNestedBatch(caps.ExtendedISupportBatchType)
 		defer rb.EndNestedBatch(batchID)
 	}
-	translatedISupport := client.t("are supported by this server")
+	finalText := "are supported by this server"
 	nick := client.Nick()
 	for _, cachedTokenLine := range lines {
 		length := len(cachedTokenLine) + 2
 		tokenline := make([]string, length)
 		tokenline[0] = nick
 		copy(tokenline[1:], cachedTokenLine)
-		tokenline[length-1] = translatedISupport
+		tokenline[length-1] = finalText
 		rb.Add(nil, server.name, RPL_ISUPPORT, tokenline...)
 	}
 }


### PR DESCRIPTION
* Limit the payload to 380 bytes instead of 400
* Don't translate the final parameter

This leaves about 60 bytes for the server name.