### PR TITLE
Fixes server crash in chathistory limit parameter

### DIFF
--- a/irc/history/targets.go
+++ b/irc/history/targets.go
@@ -27,6 +27,10 @@ func MergeTargets(base []TargetListing, extra []TargetListing, start, end time.T
 		return (start.IsZero() || start.Before(t)) && (end.IsZero() || end.After(t))
 	}
 
+	if limit < 0 {
+		limit = len(base) + len(extra)
+	}
+
 	prealloc := len(base) + len(extra)
 	if limit < prealloc {
 		prealloc = limit


### PR DESCRIPTION
When one provides a limit of -1 the prealloc gets this limit value, which is an invalid input to provide to make()