### PR TITLE
fix #2252

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -986,7 +986,7 @@ func (am *AccountManager) Verify(client *Client, account string, code string, ad
 	if client != nil {
 		am.Login(client, clientAccount)
 		if client.AlwaysOn() {
-			client.markDirty(IncludeRealname)
+			client.markDirty(IncludeAllAttrs)
 		}
 	}
 	// we may need to do nick enforcement here:
@@ -1879,6 +1879,7 @@ func (am *AccountManager) Unregister(account string, erase bool) error {
 	suspendedKey := fmt.Sprintf(keyAccountSuspended, casefoldedAccount)
 	pwResetKey := fmt.Sprintf(keyAccountPwReset, casefoldedAccount)
 	emailChangeKey := fmt.Sprintf(keyAccountEmailChange, casefoldedAccount)
+	pushSubscriptionsKey := fmt.Sprintf(keyAccountPushSubscriptions, casefoldedAccount)
 
 	var clients []*Client
 	defer func() {
@@ -1937,6 +1938,7 @@ func (am *AccountManager) Unregister(account string, erase bool) error {
 		tx.Delete(suspendedKey)
 		tx.Delete(pwResetKey)
 		tx.Delete(emailChangeKey)
+		tx.Delete(pushSubscriptionsKey)
 
 		return nil
 	})

--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -94,7 +94,6 @@ func (clients *ClientManager) SetNick(client *Client, session *Session, newNick 
 	accountName := client.accountName
 	settings := client.accountSettings
 	registered := client.registered
-	realname := client.realname
 	client.stateMutex.RUnlock()
 
 	// these restrictions have grandfather exceptions for nicknames registered
@@ -209,10 +208,6 @@ func (clients *ClientManager) SetNick(client *Client, session *Session, newNick 
 			client.server.stats.AddRegistered(invisible, operator)
 		}
 		session.autoreplayMissedSince = lastSeen
-		// TODO: transition mechanism for #1065, clean this up eventually:
-		if currentClient.Realname() == "" {
-			currentClient.SetRealname(realname)
-		}
 		// successful reattach!
 		return newNick, nil, wasAway != nowAway
 	} else if currentClient == client && currentClient.Nick() == newNick {

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -110,8 +110,8 @@ func (client *Client) AddSession(session *Session) (success bool, numSessions in
 	newSessions[len(newSessions)-1] = session
 	if client.accountSettings.AutoreplayMissed || session.deviceID != "" {
 		lastSeen = client.lastSeen[session.deviceID]
-		client.setLastSeen(time.Now().UTC(), session.deviceID)
 	}
+	client.setLastSeen(time.Now().UTC(), session.deviceID)
 	client.sessions = newSessions
 	wasAway = client.awayMessage
 	if client.autoAwayEnabledNoMutex(config) {
@@ -495,6 +495,9 @@ func (client *Client) IsExpiredAlwaysOn(config *Config) (result bool) {
 func (client *Client) checkAlwaysOnExpirationNoMutex(config *Config, ignoreRegistration bool) (result bool) {
 	if !((client.registered || ignoreRegistration) && client.alwaysOn) {
 		return false
+	}
+	if len(client.lastSeen) == 0 {
+		return true // #2252: do not precreate the client if it was never logged into at all
 	}
 	deadline := time.Duration(config.Accounts.Multiclient.AlwaysOnExpiration)
 	if deadline == 0 {

--- a/irc/server.go
+++ b/irc/server.go
@@ -428,6 +428,13 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 		c.SetMode(defaultMode, true)
 	}
 
+	// this is not a reattach, so if the client is always-on, this is the first time
+	// the Client object was created during the current server uptime. mark dirty in
+	// order to persist the realname and the user modes:
+	if c.AlwaysOn() {
+		c.markDirty(IncludeAllAttrs)
+	}
+
 	// count new user in statistics (before checking KLINEs, see #1303)
 	server.stats.Register(c.HasMode(modes.Invisible))
 


### PR DESCRIPTION
Fix SAREGISTER creating always-on clients with no user modes.

Also fix UNREGISTER/ERASE not deleting the stored push subscriptions.

This makes a few subtle changes to the state machine:

* Don't precreate the client if we never got a realname / modes assigned through an initial connection
* When the client is created through initial connection, mark it dirty right after the modes are set