### PR TITLE
metadata-2

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -1094,7 +1094,7 @@ metadata:
     # how many keys can a client subscribe to? 
     # set to 0 to disable subscriptions or -1 to allow unlimited subscriptions.
     max-subs: 100
-    # how many keys can a given target store? set to -1 to allow unlimited keys.
+    # how many keys can a user store about themselves? set to -1 to allow unlimited keys.
     max-keys: 1000
 
 # experimental support for mobile push notifications

--- a/default.yaml
+++ b/default.yaml
@@ -1087,6 +1087,16 @@ history:
 # e.g., ERGO__SERVER__MAX_SENDQ=128k. see the manual for more details.
 allow-environment-overrides: true
 
+# experimental IRC metadata support for setting key/value data on channels and nicknames.
+metadata:
+    # can clients store metadata?
+    enabled: true
+    # how many keys can a client subscribe to? 
+    # set to 0 to disable subscriptions or -1 to allow unlimited subscriptions.
+    max-subs: 100
+    # how many keys can a given target store? set to -1 to allow unlimited keys.
+    max-keys: 1000
+
 # experimental support for mobile push notifications
 # see the manual for potential security, privacy, and performance implications.
 # DO NOT enable if you are running a Tor or I2P hidden service (i.e. one

--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -237,6 +237,13 @@ CAPDEFS = [
         url="https://github.com/ircv3/ircv3-specifications/pull/471",
         standard="Soju/Goguma vendor",
     ),
+    CapDef(
+        identifier="MetadataTwoJudgementDay",
+        name="draft/metadata-2",
+        url="https://ircv3.net/specs/extensions/metadata",
+        standard="draft IRCv3",
+    ),
+
 ]
 
 def validate_defs():

--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -238,7 +238,7 @@ CAPDEFS = [
         standard="Soju/Goguma vendor",
     ),
     CapDef(
-        identifier="MetadataTwoJudgementDay",
+        identifier="Metadata",
         name="draft/metadata-2",
         url="https://ircv3.net/specs/extensions/metadata",
         standard="draft IRCv3",

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -7,7 +7,7 @@ package caps
 
 const (
 	// number of recognized capabilities:
-	numCapabs = 37
+	numCapabs = 38
 	// length of the uint32 array that represents the bitset:
 	bitsetLen = 2
 )
@@ -64,6 +64,10 @@ const (
 	// MessageRedaction is the proposed IRCv3 capability named "draft/message-redaction":
 	// https://github.com/progval/ircv3-specifications/blob/redaction/extensions/message-redaction.md
 	MessageRedaction Capability = iota
+
+	// MetadataTwoJudgementDay is the draft IRCv3 capability named "draft/metadata-2":
+	// https://ircv3.net/specs/extensions/metadata
+	MetadataTwoJudgementDay Capability = iota
 
 	// Multiline is the proposed IRCv3 capability named "draft/multiline":
 	// https://github.com/ircv3/ircv3-specifications/pull/398
@@ -178,6 +182,7 @@ var (
 		"draft/extended-isupport",
 		"draft/languages",
 		"draft/message-redaction",
+		"draft/metadata-2",
 		"draft/multiline",
 		"draft/no-implicit-names",
 		"draft/persistence",

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -65,9 +65,9 @@ const (
 	// https://github.com/progval/ircv3-specifications/blob/redaction/extensions/message-redaction.md
 	MessageRedaction Capability = iota
 
-	// MetadataTwoJudgementDay is the draft IRCv3 capability named "draft/metadata-2":
+	// Metadata is the draft IRCv3 capability named "draft/metadata-2":
 	// https://ircv3.net/specs/extensions/metadata
-	MetadataTwoJudgementDay Capability = iota
+	Metadata Capability = iota
 
 	// Multiline is the proposed IRCv3 capability named "draft/multiline":
 	// https://github.com/ircv3/ircv3-specifications/pull/398

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -55,6 +55,7 @@ type Channel struct {
 	dirtyBits         uint
 	settings          ChannelSettings
 	uuid              utils.UUID
+	metadata          MetadataStore
 	// these caches are paired to allow iteration over channel members without holding the lock
 	membersCache    []*Client
 	memberDataCache []*memberData
@@ -126,6 +127,7 @@ func (channel *Channel) applyRegInfo(chanReg RegisteredChannel) {
 	channel.userLimit = chanReg.UserLimit
 	channel.settings = chanReg.Settings
 	channel.forward = chanReg.Forward
+	channel.metadata = chanReg.Metadata
 
 	for _, mode := range chanReg.Modes {
 		channel.flags.SetMode(mode, true)
@@ -163,6 +165,7 @@ func (channel *Channel) ExportRegistration() (info RegisteredChannel) {
 	info.AccountToUMode = maps.Clone(channel.accountToUMode)
 
 	info.Settings = channel.settings
+	info.Metadata = channel.metadata
 
 	return
 }

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -55,7 +55,7 @@ type Channel struct {
 	dirtyBits         uint
 	settings          ChannelSettings
 	uuid              utils.UUID
-	metadata          MetadataStore
+	metadata          map[string]string
 	// these caches are paired to allow iteration over channel members without holding the lock
 	membersCache    []*Client
 	memberDataCache []*memberData
@@ -893,6 +893,10 @@ func (channel *Channel) Join(client *Client, key string, isSajoin bool, rb *Resp
 
 	if rb.session.capabilities.Has(caps.ReadMarker) {
 		rb.Add(nil, client.server.name, "MARKREAD", chname, client.GetReadMarker(chcfname))
+	}
+
+	if rb.session.capabilities.Has(caps.Metadata) {
+		syncChannelMetadata(client.server, rb, channel)
 	}
 
 	if rb.session.client == client {

--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -64,7 +64,7 @@ type RegisteredChannel struct {
 	// Settings are the chanserv-modifiable settings
 	Settings ChannelSettings
 	// Metadata set using the METADATA command
-	Metadata MetadataStore
+	Metadata map[string]string
 }
 
 func (r *RegisteredChannel) Serialize() ([]byte, error) {

--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -63,6 +63,8 @@ type RegisteredChannel struct {
 	Invites map[string]MaskInfo
 	// Settings are the chanserv-modifiable settings
 	Settings ChannelSettings
+	// Metadata set using the METADATA command
+	Metadata MetadataStore
 }
 
 func (r *RegisteredChannel) Serialize() ([]byte, error) {

--- a/irc/client.go
+++ b/irc/client.go
@@ -131,7 +131,7 @@ type Client struct {
 	clearablePushMessages   map[string]time.Time
 	pushSubscriptionsExist  atomic.Uint32 // this is a cache on len(pushSubscriptions) != 0
 	pushQueue               pushQueue
-	metadata                MetadataStore
+	metadata                map[string]string
 }
 
 type saslStatus struct {
@@ -216,7 +216,7 @@ type Session struct {
 
 	webPushEndpoint string // goroutine-local: web push endpoint registered by the current session
 
-	metadataSubscriptions []string
+	metadataSubscriptions utils.HashSet[string]
 }
 
 // MultilineBatch tracks the state of a client-to-server multiline batch.

--- a/irc/client.go
+++ b/irc/client.go
@@ -131,6 +131,7 @@ type Client struct {
 	clearablePushMessages   map[string]time.Time
 	pushSubscriptionsExist  atomic.Uint32 // this is a cache on len(pushSubscriptions) != 0
 	pushQueue               pushQueue
+	metadata                MetadataStore
 }
 
 type saslStatus struct {
@@ -214,6 +215,8 @@ type Session struct {
 	batch MultilineBatch
 
 	webPushEndpoint string // goroutine-local: web push endpoint registered by the current session
+
+	metadataSubscriptions []string
 }
 
 // MultilineBatch tracks the state of a client-to-server multiline batch.
@@ -1129,6 +1132,7 @@ func (client *Client) SetNick(nick, nickCasefolded, skeleton string) (success bo
 	client.nickCasefolded = nickCasefolded
 	client.skeleton = skeleton
 	client.updateNickMaskNoMutex()
+
 	return true
 }
 

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -209,6 +209,10 @@ func init() {
 			handler:   markReadHandler,
 			minParams: 0, // send FAIL instead of ERR_NEEDMOREPARAMS
 		},
+		"METADATA": {
+			handler:   metadataHandler,
+			minParams: 2,
+		},
 		"MODE": {
 			handler:   modeHandler,
 			minParams: 1,

--- a/irc/config.go
+++ b/irc/config.go
@@ -1646,7 +1646,7 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 
 	if !config.Metadata.Enabled {
-		config.Server.supportedCaps.Disable(caps.MetadataTwoJudgementDay)
+		config.Server.supportedCaps.Disable(caps.Metadata)
 	} else {
 		var metadataValues []string
 		if config.Metadata.MaxSubs >= 0 {
@@ -1659,7 +1659,7 @@ func LoadConfig(filename string) (config *Config, err error) {
 			metadataValues = append(metadataValues, fmt.Sprintf("max-value-bytes=%d", config.Metadata.MaxValueBytes))
 		}
 		if len(metadataValues) != 0 {
-			config.Server.capValues[caps.MetadataTwoJudgementDay] = strings.Join(metadataValues, ",")
+			config.Server.capValues[caps.Metadata] = strings.Join(metadataValues, ",")
 		}
 
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -728,7 +728,7 @@ type Config struct {
 		Enabled       bool
 		MaxSubs       int `yaml:"max-subs"`
 		MaxKeys       int `yaml:"max-keys"`
-		MaxValueBytes int `yaml:"max-value-length"`
+		MaxValueBytes int `yaml:"max-value-length"` // todo: currently unenforced!!
 	}
 
 	WebPush struct {

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -891,10 +891,7 @@ func (channel *Channel) GetMetadata(key string) (string, bool) {
 	defer channel.stateMutex.RUnlock()
 
 	val, ok := channel.metadata[key]
-	if !ok {
-		return "", false
-	}
-	return val, true
+	return val, ok
 }
 
 func (channel *Channel) SetMetadata(key string, value string) {
@@ -990,10 +987,6 @@ func (client *Client) ClearMetadata() map[string]string {
 func (client *Client) CountMetadata() int {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
-
-	if client.metadata == nil {
-		return 0
-	}
 
 	return len(client.metadata)
 }

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -935,6 +935,17 @@ func (channel *Channel) ClearMetadata() MetadataStore {
 	return oldMap
 }
 
+func (channel *Channel) CountMetadata() int {
+	channel.stateMutex.RLock()
+	defer channel.stateMutex.RUnlock()
+
+	if channel.metadata == nil {
+		return 0
+	}
+
+	return len(channel.metadata)
+}
+
 func (client *Client) GetMetadata(key string) (string, error) {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
@@ -981,4 +992,15 @@ func (client *Client) ClearMetadata() MetadataStore {
 	client.metadata = make(MetadataStore)
 
 	return oldMap
+}
+
+func (client *Client) CountMetadata() int {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+
+	if client.metadata == nil {
+		return 0
+	}
+
+	return len(client.metadata)
 }

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3201,8 +3201,8 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 				continue
 			}
 
-			val, err := t.GetMetadata(key)
-			if err == errMetadataNotFound {
+			val, ok := t.GetMetadata(key)
+			if !ok {
 				rb.Add(nil, server.name, RPL_KEYNOTSET, client.Nick(), target, key, client.t("Key is not set"))
 				continue
 			}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3097,6 +3097,206 @@ func markReadHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 	return
 }
 
+// METADATA <target> <subcommand> [<and so on>...]
+func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) (exiting bool) {
+	originalTarget := msg.Params[0]
+	target := originalTarget
+
+	if !server.Config().Metadata.Enabled {
+		rb.Add(nil, server.name, "FAIL", "METADATA", "FORBIDDEN", originalTarget, "Metadata is disabled on this server")
+		return
+	}
+
+	subcommand := strings.ToLower(msg.Params[1])
+
+	invalidTarget := func() {
+		rb.Add(nil, server.name, "FAIL", "METADATA", "INVALID_TARGET", originalTarget, client.t("Invalid metadata target"))
+	}
+	noKeyPerms := func(key string) {
+		rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_NO_PERMISSION", originalTarget, key, client.t("You do not have permission to perform this action"))
+	}
+
+	if target == "*" {
+		target = client.Nick()
+	}
+
+	targetClient := server.clients.Get(target)
+	targetChannel := server.channels.Get(target)
+	if !metadataCanISeeThisTarget(client, target) {
+		invalidTarget()
+		return
+	}
+
+	var t MetadataHaver
+	if targetClient != nil {
+		t = targetClient
+	}
+	if targetChannel != nil {
+		t = targetChannel
+	}
+	if t == nil {
+		invalidTarget()
+		return
+	}
+
+	needsKey := subcommand == "set" || subcommand == "get" || subcommand == "sub" || subcommand == "unsub"
+	if needsKey && len(msg.Params) <= 2 {
+		rb.Add(nil, server.name, ERR_NEEDMOREPARAMS, client.Nick(), msg.Command, client.t("Not enough parameters"))
+		return
+	}
+
+	switch subcommand {
+	case "set":
+		key := strings.ToLower(msg.Params[2])
+		if metadataKeyIsEvil(key) {
+			rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_INVALID", key, client.t("Invalid key name"))
+			return
+		}
+
+		if !metadataCanIEditThisKey(client, target, key) {
+			noKeyPerms(key)
+			return
+		}
+
+		if len(msg.Params) > 3 {
+			value := msg.Params[3]
+			const maxCombinedLen = 350
+
+			if len(key)+len(value) > maxCombinedLen {
+				rb.Add(nil, server.name, "FAIL", "METADATA", "VALUE_INVALID", client.t("Value is too long"))
+				return
+			}
+
+			server.logger.Debug("metadata", "setting", key, value, "on", target)
+
+			t.SetMetadata(key, value)
+			notifySubscribers(server, rb.session, target, key, value)
+
+			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, "*", value)
+		} else {
+			server.logger.Debug("metadata", "deleting", key, "on", target)
+			t.DeleteMetadata(key)
+			notifySubscribers(server, rb.session, target, key, "")
+
+			rb.Add(nil, server.name, RPL_KEYNOTSET, client.Nick(), target, key, client.t("Key deleted"))
+		}
+
+	case "get":
+		batchId := rb.StartNestedBatch("metadata")
+		defer rb.EndNestedBatch(batchId)
+
+		for _, key := range msg.Params[2:] {
+			if metadataKeyIsEvil(key) {
+				rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_INVALID", key, client.t("Invalid key name"))
+				continue
+			}
+
+			val, err := t.GetMetadata(key)
+			if err == errMetadataNotFound {
+				rb.Add(nil, server.name, RPL_KEYNOTSET, client.Nick(), target, key, client.t("Key is not set"))
+				continue
+			}
+
+			visibility := "*"
+			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, visibility, val)
+		}
+
+	case "list":
+		values := t.ListMetadata()
+
+		batchId := rb.StartNestedBatch("metadata")
+		defer rb.EndNestedBatch(batchId)
+
+		for key, val := range values {
+			visibility := "*"
+
+			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, visibility, val)
+		}
+
+	case "clear":
+		if !metadataCanIEditThisTarget(client, target) {
+			invalidTarget()
+			return
+		}
+
+		values := t.ClearMetadata()
+
+		batchId := rb.StartNestedBatch("metadata")
+		defer rb.EndNestedBatch(batchId)
+
+		for key, val := range values {
+			visibility := "*"
+			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, visibility, val)
+		}
+
+	case "sub":
+		keys := msg.Params[2:]
+		server.logger.Debug("metadata", client.nick, "has subscrumbled to", strings.Join(keys, ", "))
+		added, err := rb.session.SubscribeTo(keys...)
+		if err == errMetadataTooManySubs {
+			bad := keys[len(added)] // get the key that broke the camel's back
+			rb.Add(nil, server.name, "FAIL", "METADATA", "TOO_MANY_SUBS", bad, client.t("Too many subscriptions"))
+		}
+
+		lineLength := MaxLineLen - len(server.name) - len(RPL_METADATASUBOK) - len(client.Nick()) - 10
+
+		chunked := utils.ChunkifyParams(added, lineLength)
+		for _, line := range chunked {
+			params := append([]string{client.Nick()}, line...)
+			rb.Add(nil, server.name, RPL_METADATASUBS, params...)
+		}
+
+	case "unsub":
+		keys := msg.Params[2:]
+		server.logger.Debug("metadata", client.nick, "has UNsubscrumbled to", strings.Join(keys, ", "))
+		removed := rb.session.UnsubscribeFrom(keys...)
+
+		lineLength := MaxLineLen - len(server.name) - len(RPL_METADATAUNSUBOK) - len(client.Nick()) - 10
+		chunked := utils.ChunkifyParams(removed, lineLength)
+		for _, line := range chunked {
+			params := append([]string{client.Nick()}, line...)
+			rb.Add(nil, server.name, RPL_METADATASUBS, params...)
+		}
+
+	case "subs":
+		lineLength := MaxLineLen - len(server.name) - len(RPL_METADATASUBS) - len(client.Nick()) - 10 // for safety
+
+		chunked := utils.ChunkifyParams(rb.session.MetadataSubscriptions(), lineLength)
+		for _, line := range chunked {
+			params := append([]string{client.Nick()}, line...)
+			rb.Add(nil, server.name, RPL_METADATASUBS, params...)
+		}
+
+	case "sync":
+		batchId := rb.StartNestedBatch("metadata")
+		defer rb.EndNestedBatch(batchId)
+
+		values := t.ListMetadata()
+		for k, v := range values {
+			if rb.session.isSubscribedTo(k) {
+				visibility := "*"
+				rb.Add(nil, server.name, "METADATA", target, k, visibility, v)
+			}
+		}
+		if targetChannel != nil {
+			for _, client := range targetChannel.Members() {
+				values := client.ListMetadata()
+				for k, v := range values {
+					if rb.session.isSubscribedTo(k) {
+						visibility := "*"
+						rb.Add(nil, server.name, "METADATA", client.Nick(), k, visibility, v)
+					}
+				}
+			}
+		}
+
+	default:
+		rb.Add(nil, server.name, "FAIL", "METADATA", "SUBCOMMAND_INVALID", msg.Params[1], client.t("Invalid subcommand"))
+	}
+
+	return
+}
+
 // REHASH
 func rehashHandler(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
 	nick := client.Nick()

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3167,6 +3167,14 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 				return
 			}
 
+			maxKeys := server.Config().Metadata.MaxKeys
+			isSelf := targetClient != nil && client == targetClient
+
+			if isSelf && maxKeys > 0 && t.CountMetadata() >= maxKeys {
+				rb.Add(nil, server.name, "FAIL", "METADATA", "LIMIT_REACHED", client.nick, client.t("You have too many keys set on yourself"))
+				return
+			}
+
 			server.logger.Debug("metadata", "setting", key, value, "on", target)
 
 			t.SetMetadata(key, value)

--- a/irc/help.go
+++ b/irc/help.go
@@ -340,6 +340,12 @@ MARKREAD updates an IRCv3 read message marker. It is not intended for use by
 end users. For more details, see the latest draft of the read-marker
 specification.`,
 	},
+	"metadata": {
+		text: `METADATA <target> <subcommand> [<everything else>...]
+		
+Retrieve and meddle with metadata for the given target.
+Have a look at https://ircv3.net/specs/extensions/metadata for interesting technical information.`,
+	},
 	"mode": {
 		text: `MODE <target> [<modestring> [<mode arguments>...]]
 

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -17,7 +17,7 @@ var (
 
 type MetadataHaver = interface {
 	SetMetadata(key string, value string)
-	GetMetadata(key string) (string, error)
+	GetMetadata(key string) (string, bool)
 	DeleteMetadata(key string)
 	ListMetadata() map[string]string
 	ClearMetadata() map[string]string

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -1,0 +1,121 @@
+package irc
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/ergochat/ergo/irc/caps"
+	"github.com/ergochat/ergo/irc/modes"
+	"github.com/ergochat/ergo/irc/utils"
+)
+
+var (
+	errMetadataTooManySubs = errors.New("too many subscriptions")
+	errMetadataNotFound    = errors.New("key not found")
+)
+
+type MetadataStore = map[string]string
+
+type MetadataHaver = interface {
+	SetMetadata(key string, value string)
+	GetMetadata(key string) (string, error)
+	DeleteMetadata(key string)
+	ListMetadata() MetadataStore
+	ClearMetadata() MetadataStore
+}
+
+func notifySubscribers(server *Server, session *Session, target string, key string, value string) {
+	var notify utils.HashSet[*Session] = make(utils.HashSet[*Session])
+	targetChannel := server.channels.Get(target)
+	targetClient := server.clients.Get(target)
+
+	if targetClient != nil {
+		notify = targetClient.FriendsMonitors(caps.MetadataTwoJudgementDay)
+		// notify clients about changes regarding themselves
+		for _, s := range targetClient.Sessions() {
+			notify.Add(s)
+		}
+	}
+	if targetChannel != nil {
+		members := targetChannel.Members()
+		for _, m := range members {
+			for _, s := range m.Sessions() {
+				if s.capabilities.Has(caps.MetadataTwoJudgementDay) {
+					notify.Add(s)
+				}
+			}
+		}
+	}
+
+	// don't notify the session that made the change
+	notify.Remove(session)
+
+	for s := range notify {
+		if !s.isSubscribedTo(key) {
+			continue
+		}
+
+		if value != "" {
+			s.Send(nil, server.name, "METADATA", target, key, "*", value)
+		} else {
+			s.Send(nil, server.name, "METADATA", target, key, "*")
+		}
+	}
+}
+
+var metadataEvilCharsRegexp = regexp.MustCompile("[^A-Za-z0-9_./:-]+")
+
+func metadataKeyIsEvil(key string) bool {
+	key = strings.TrimSpace(key) // just in case
+
+	return len(key) == 0 || // key needs to contain stuff
+		key[0] == ':' || // key can't start with a colon
+		metadataEvilCharsRegexp.MatchString(key) // key can't contain the stuff it can't contain
+}
+
+func metadataCanIEditThisKey(client *Client, target string, _ string) bool {
+	if !metadataCanIEditThisTarget(client, target) { // you can't edit keys on targets you can't edit.
+		return false
+	}
+
+	// todo: we don't actually do anything regarding visibility yet so there's not much to do here
+
+	return true
+}
+
+func metadataCanIEditThisTarget(client *Client, target string) bool {
+	if !metadataCanISeeThisTarget(client, target) { // you can't edit what you can't see. a wise man told me this once
+		return false
+	}
+
+	if client.HasRoleCapabs("sajoin") { // sajoin opers can do whatever they want
+		return true
+	}
+
+	if target == client.Nick() { // your right to swing your fist ends where my nose begins
+		return true
+	}
+
+	// if you're a channel operator, knock yourself out
+	channel := client.server.channels.Get(target)
+	if channel != nil && channel.ClientIsAtLeast(client, modes.Operator) {
+		return true
+	}
+
+	return false
+}
+
+func metadataCanISeeThisTarget(client *Client, target string) bool {
+	if client.HasRoleCapabs("sajoin") { // sajoin opers can do whatever they want
+		return true
+	}
+
+	// check if the user is in the channel
+	channel := client.server.channels.Get(target)
+	if channel != nil && !channel.hasClient(client) {
+		return false
+	}
+
+	return true
+}

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -23,6 +23,7 @@ type MetadataHaver = interface {
 	DeleteMetadata(key string)
 	ListMetadata() MetadataStore
 	ClearMetadata() MetadataStore
+	CountMetadata() int
 }
 
 func notifySubscribers(server *Server, session *Session, target string, key string, value string) {

--- a/irc/metadata_test.go
+++ b/irc/metadata_test.go
@@ -1,0 +1,21 @@
+package irc
+
+import "testing"
+
+func TestKeyCheck(t *testing.T) {
+	cases := []struct {
+		input  string
+		isEvil bool
+	}{
+		{"ImNormal", false},
+		{":imevil", true},
+		{"key£with$not%allowed^chars", true},
+		{"key.that:s_completely/normal-and.fine", false},
+	}
+
+	for _, c := range cases {
+		if metadataKeyIsEvil(c.input) != c.isEvil {
+			t.Errorf("%s should have returned %v. but it didn't. so that's not great", c.input, c.isEvil)
+		}
+	}
+}

--- a/irc/numerics.go
+++ b/irc/numerics.go
@@ -183,6 +183,11 @@ const (
 	RPL_MONLIST            = "732"
 	RPL_ENDOFMONLIST       = "733"
 	ERR_MONLISTFULL        = "734"
+	RPL_KEYVALUE           = "761" // metadata numerics
+	RPL_KEYNOTSET          = "766"
+	RPL_METADATASUBOK      = "770"
+	RPL_METADATAUNSUBOK    = "771"
+	RPL_METADATASUBS       = "772"
 	RPL_LOGGEDIN           = "900"
 	RPL_LOGGEDOUT          = "901"
 	ERR_NICKLOCKED         = "902"

--- a/irc/utils/chunks.go
+++ b/irc/utils/chunks.go
@@ -1,0 +1,22 @@
+package utils
+
+func ChunkifyParams(params []string, maxChars int) [][]string {
+	var chunked [][]string
+
+	var acc []string
+	var length = 0
+
+	for _, p := range params {
+		length = length + len(p) + 1 // (accounting for the space)
+
+		if length > maxChars {
+			chunked = append(chunked, acc)
+			acc = []string{}
+			length = 0
+		}
+
+		acc = append(acc, p)
+	}
+
+	return chunked
+}

--- a/irc/utils/chunks.go
+++ b/irc/utils/chunks.go
@@ -1,12 +1,14 @@
 package utils
 
-func ChunkifyParams(params []string, maxChars int) [][]string {
+import "iter"
+
+func ChunkifyParams(params iter.Seq[string], maxChars int) [][]string {
 	var chunked [][]string
 
 	var acc []string
 	var length = 0
 
-	for _, p := range params {
+	for p := range params {
 		length = length + len(p) + 1 // (accounting for the space)
 
 		if length > maxChars {
@@ -16,6 +18,10 @@ func ChunkifyParams(params []string, maxChars int) [][]string {
 		}
 
 		acc = append(acc, p)
+	}
+
+	if len(acc) != 0 {
+		chunked = append(chunked, acc)
 	}
 
 	return chunked

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -1058,6 +1058,13 @@ history:
 # e.g., ERGO__SERVER__MAX_SENDQ=128k. see the manual for more details.
 allow-environment-overrides: true
 
+# experimental IRC metadata support for setting key/value data on channels and nicknames.
+metadata:
+    # can clients use the metadata command?
+    enabled: true
+    # how many keys can a client subscribe to?
+    max-subs: 1000
+
 # experimental support for mobile push notifications
 # see the manual for potential security, privacy, and performance implications.
 # DO NOT enable if you are running a Tor or I2P hidden service (i.e. one


### PR DESCRIPTION
adds support for most of the draft/[metadata-2](https://www.youtube.com/watch?v=Sr57Je1fVvM&t=18s) spec

fixes #1745

what's new:
* a new draft/metadata-2 cap
* the metadata command, with SET, GET, CLEAR, LIST, SUB, UNSUB, SUBS & SYNC
* a `metadata` section in the config

what's missing:
* before-connect
* visibility controls. as of right now everything is * 
* any attempt at rate limiting
* postponed synchronisation

this is a draft because i still need to write some tests but i thought i'd open a pr so someone can tell me if i've done something egregiously wrong (this is my first time doing anything particularly substantial in go (!!!!))