### PR TITLE
round 1 of follow-up for metadata

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -724,6 +724,7 @@ oper-classes:
             - "history"      # modify or delete history messages
             - "defcon"       # use the DEFCON command (restrict server capabilities)
             - "massmessage"  # message all users on the server
+            - "metadata"     # modify arbitrary metadata on channels and users
 
 # ircd operators
 opers:

--- a/default.yaml
+++ b/default.yaml
@@ -1087,11 +1087,11 @@ history:
 # e.g., ERGO__SERVER__MAX_SENDQ=128k. see the manual for more details.
 allow-environment-overrides: true
 
-# experimental IRC metadata support for setting key/value data on channels and nicknames.
+# metadata support for setting key/value data on channels and nicknames.
 metadata:
     # can clients store metadata?
     enabled: true
-    # how many keys can a client subscribe to? 
+    # how many keys can a client subscribe to?
     # set to 0 to disable subscriptions or -1 to allow unlimited subscriptions.
     max-subs: 100
     # how many keys can a user store about themselves? set to -1 to allow unlimited keys.

--- a/default.yaml
+++ b/default.yaml
@@ -1093,10 +1093,9 @@ metadata:
     # can clients store metadata?
     enabled: true
     # how many keys can a client subscribe to?
-    # set to 0 to disable subscriptions or -1 to allow unlimited subscriptions.
     max-subs: 100
-    # how many keys can a user store about themselves? set to -1 to allow unlimited keys.
-    max-keys: 1000
+    # how many keys can be stored per entity?
+    max-keys: 100
 
 # experimental support for mobile push notifications
 # see the manual for potential security, privacy, and performance implications.

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -7,6 +7,7 @@ package irc
 
 import (
 	"fmt"
+	"iter"
 	"maps"
 	"strconv"
 	"strings"
@@ -1674,6 +1675,20 @@ func (channel *Channel) auditoriumFriends(client *Client) (friends []*Client) {
 		}
 	}
 	return
+}
+
+func (channel *Channel) sessionsWithCap(capabs ...caps.Capability) iter.Seq[*Session] {
+	return func(yield func(*Session) bool) {
+		for _, member := range channel.Members() {
+			for _, sess := range member.Sessions() {
+				if sess.capabilities.HasAll(capabs...) {
+					if !yield(sess) {
+						return
+					}
+				}
+			}
+		}
+	}
 }
 
 // returns whether the client is visible to unprivileged users in the channel

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1677,7 +1677,7 @@ func (channel *Channel) auditoriumFriends(client *Client) (friends []*Client) {
 	return
 }
 
-func (channel *Channel) sessionsWithCap(capabs ...caps.Capability) iter.Seq[*Session] {
+func (channel *Channel) sessionsWithCaps(capabs ...caps.Capability) iter.Seq[*Session] {
 	return func(yield func(*Session) bool) {
 		for _, member := range channel.Members() {
 			for _, sess := range member.Sessions() {

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -206,6 +206,10 @@ func (cm *ChannelManager) Cleanup(channel *Channel) {
 }
 
 func (cm *ChannelManager) SetRegistered(channelName string, account string) (err error) {
+	if account == "" {
+		return errAuthRequired // this is already enforced by ChanServ, but do a final check
+	}
+
 	if cm.server.Defcon() <= 4 {
 		return errFeatureDisabled
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -728,7 +728,7 @@ type Config struct {
 		Enabled       bool
 		MaxSubs       int `yaml:"max-subs"`
 		MaxKeys       int `yaml:"max-keys"`
-		MaxValueBytes int `yaml:"max-value-length"` // todo: currently unenforced!!
+		MaxValueBytes int `yaml:"max-value-length"`
 	}
 
 	WebPush struct {

--- a/irc/config.go
+++ b/irc/config.go
@@ -1649,19 +1649,20 @@ func LoadConfig(filename string) (config *Config, err error) {
 		config.Server.supportedCaps.Disable(caps.Metadata)
 	} else {
 		var metadataValues []string
-		if config.Metadata.MaxSubs >= 0 {
-			metadataValues = append(metadataValues, fmt.Sprintf("max-subs=%d", config.Metadata.MaxSubs))
+		// these are required for normal operation, so set sane defaults:
+		if config.Metadata.MaxSubs == 0 {
+			config.Metadata.MaxSubs = 10
 		}
-		if config.Metadata.MaxKeys > 0 {
-			metadataValues = append(metadataValues, fmt.Sprintf("max-keys=%d", config.Metadata.MaxKeys))
+		metadataValues = append(metadataValues, fmt.Sprintf("max-subs=%d", config.Metadata.MaxSubs))
+		if config.Metadata.MaxKeys == 0 {
+			config.Metadata.MaxKeys = 10
 		}
+		metadataValues = append(metadataValues, fmt.Sprintf("max-keys=%d", config.Metadata.MaxKeys))
+		// this is not required since we enforce a hardcoded upper bound on key+value
 		if config.Metadata.MaxValueBytes > 0 {
 			metadataValues = append(metadataValues, fmt.Sprintf("max-value-bytes=%d", config.Metadata.MaxValueBytes))
 		}
-		if len(metadataValues) != 0 {
-			config.Server.capValues[caps.Metadata] = strings.Join(metadataValues, ",")
-		}
-
+		config.Server.capValues[caps.Metadata] = strings.Join(metadataValues, ",")
 	}
 
 	err = config.processExtjwt()

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -33,6 +33,7 @@ var (
 	errAccountVerificationInvalidCode = errors.New("Invalid account verification code")
 	errAccountUpdateFailed            = errors.New(`Error while updating your account information`)
 	errAccountMustHoldNick            = errors.New(`You must hold that nickname in order to register it`)
+	errAuthRequired                   = errors.New("You must be logged into an account to do this")
 	errAuthzidAuthcidMismatch         = errors.New(`authcid and authzid must be the same`)
 	errCertfpAlreadyExists            = errors.New(`An account already exists for your certificate fingerprint`)
 	errChannelNotOwnedByAccount       = errors.New("Channel not owned by the specified account")

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -894,7 +894,7 @@ func (channel *Channel) GetMetadata(key string) (string, bool) {
 	return val, ok
 }
 
-func (channel *Channel) SetMetadata(key string, value string) {
+func (channel *Channel) SetMetadata(key string, value string) (updated bool) {
 	defer channel.MarkDirty(IncludeAllAttrs)
 
 	channel.stateMutex.Lock()
@@ -904,7 +904,12 @@ func (channel *Channel) SetMetadata(key string, value string) {
 		channel.metadata = make(map[string]string)
 	}
 
-	channel.metadata[key] = value
+	existing, ok := channel.metadata[key]
+	updated = !ok || value != existing
+	if updated {
+		channel.metadata[key] = value
+	}
+	return updated
 }
 
 func (channel *Channel) ListMetadata() map[string]string {
@@ -914,13 +919,17 @@ func (channel *Channel) ListMetadata() map[string]string {
 	return maps.Clone(channel.metadata)
 }
 
-func (channel *Channel) DeleteMetadata(key string) {
+func (channel *Channel) DeleteMetadata(key string) (updated bool) {
 	defer channel.MarkDirty(IncludeAllAttrs)
 
 	channel.stateMutex.Lock()
 	defer channel.stateMutex.Unlock()
 
-	delete(channel.metadata, key)
+	_, updated = channel.metadata[key]
+	if updated {
+		delete(channel.metadata, key)
+	}
+	return updated
 }
 
 func (channel *Channel) ClearMetadata() map[string]string {
@@ -949,7 +958,7 @@ func (client *Client) GetMetadata(key string) (string, bool) {
 	return val, ok
 }
 
-func (client *Client) SetMetadata(key string, value string) {
+func (client *Client) SetMetadata(key string, value string) (updated bool) {
 	client.stateMutex.Lock()
 	defer client.stateMutex.Unlock()
 
@@ -957,7 +966,12 @@ func (client *Client) SetMetadata(key string, value string) {
 		client.metadata = make(map[string]string)
 	}
 
-	client.metadata[key] = value
+	existing, ok := client.metadata[key]
+	updated = !ok || value != existing
+	if updated {
+		client.metadata[key] = value
+	}
+	return updated
 }
 
 func (client *Client) ListMetadata() map[string]string {
@@ -967,11 +981,15 @@ func (client *Client) ListMetadata() map[string]string {
 	return maps.Clone(client.metadata)
 }
 
-func (client *Client) DeleteMetadata(key string) {
+func (client *Client) DeleteMetadata(key string) (updated bool) {
 	client.stateMutex.Lock()
 	defer client.stateMutex.Unlock()
 
-	delete(client.metadata, key)
+	_, updated = client.metadata[key]
+	if updated {
+		delete(client.metadata, key)
+	}
+	return updated
 }
 
 func (client *Client) ClearMetadata() map[string]string {

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -894,7 +894,7 @@ func (channel *Channel) GetMetadata(key string) (string, bool) {
 	return val, ok
 }
 
-func (channel *Channel) SetMetadata(key string, value string) (updated bool) {
+func (channel *Channel) SetMetadata(key string, value string, limit int) (updated bool, err error) {
 	defer channel.MarkDirty(IncludeAllAttrs)
 
 	channel.stateMutex.Lock()
@@ -905,11 +905,14 @@ func (channel *Channel) SetMetadata(key string, value string) (updated bool) {
 	}
 
 	existing, ok := channel.metadata[key]
+	if !ok && len(channel.metadata) >= limit {
+		return false, errLimitExceeded
+	}
 	updated = !ok || value != existing
 	if updated {
 		channel.metadata[key] = value
 	}
-	return updated
+	return updated, nil
 }
 
 func (channel *Channel) ListMetadata() map[string]string {
@@ -958,7 +961,7 @@ func (client *Client) GetMetadata(key string) (string, bool) {
 	return val, ok
 }
 
-func (client *Client) SetMetadata(key string, value string) (updated bool) {
+func (client *Client) SetMetadata(key string, value string, limit int) (updated bool, err error) {
 	client.stateMutex.Lock()
 	defer client.stateMutex.Unlock()
 
@@ -967,11 +970,14 @@ func (client *Client) SetMetadata(key string, value string) (updated bool) {
 	}
 
 	existing, ok := client.metadata[key]
+	if !ok && len(client.metadata) >= limit {
+		return false, errLimitExceeded
+	}
 	updated = !ok || value != existing
 	if updated {
 		client.metadata[key] = value
 	}
-	return updated
+	return updated, nil
 }
 
 func (client *Client) ListMetadata() map[string]string {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3155,7 +3155,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 	case "set":
 		key := strings.ToLower(msg.Params[2])
 		if metadataKeyIsEvil(key) {
-			rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_INVALID", key, client.t("Invalid key name"))
+			rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_INVALID", utils.SafeErrorParam(key), client.t("Invalid key name"))
 			return
 		}
 
@@ -3183,7 +3183,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 			isSelf := targetClient != nil && client == targetClient
 
 			if isSelf && maxKeys > 0 && targetObj.CountMetadata() >= maxKeys {
-				rb.Add(nil, server.name, "FAIL", "METADATA", "LIMIT_REACHED", client.nick, client.t("You have too many keys set on yourself"))
+				rb.Add(nil, server.name, "FAIL", "METADATA", "LIMIT_REACHED", client.t("You have too many keys set on yourself"))
 				return
 			}
 
@@ -3211,7 +3211,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 		for _, key := range msg.Params[2:] {
 			if metadataKeyIsEvil(key) {
-				rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_INVALID", key, client.t("Invalid key name"))
+				rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_INVALID", utils.SafeErrorParam(key), client.t("Invalid key name"))
 				continue
 			}
 
@@ -3246,10 +3246,11 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 	case "sub":
 		keys := msg.Params[2:]
+		// TODO validate key names here
 		added, err := rb.session.SubscribeTo(keys...)
 		if err == errMetadataTooManySubs {
 			bad := keys[len(added)] // get the key that broke the camel's back
-			rb.Add(nil, server.name, "FAIL", "METADATA", "TOO_MANY_SUBS", bad, client.t("Too many subscriptions"))
+			rb.Add(nil, server.name, "FAIL", "METADATA", "TOO_MANY_SUBS", utils.SafeErrorParam(bad), client.t("Too many subscriptions"))
 		}
 
 		lineLength := MaxLineLen - len(server.name) - len(RPL_METADATASUBOK) - len(client.Nick()) - 10
@@ -3291,7 +3292,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 		}
 
 	default:
-		rb.Add(nil, server.name, "FAIL", "METADATA", "SUBCOMMAND_INVALID", msg.Params[1], client.t("Invalid subcommand"))
+		rb.Add(nil, server.name, "FAIL", "METADATA", "SUBCOMMAND_INVALID", utils.SafeErrorParam(msg.Params[1]), client.t("Invalid subcommand"))
 	}
 
 	return

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3129,11 +3129,13 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 		targetChannel = server.channels.Get(target)
 		if targetChannel != nil {
 			targetObj = targetChannel
+			target = targetChannel.Name() // canonicalize case
 		}
 	} else {
 		targetClient = server.clients.Get(target)
 		if targetClient != nil {
 			targetObj = targetClient
+			target = targetClient.Nick() // canonicalize case
 		}
 	}
 	if targetObj == nil {
@@ -3180,13 +3182,14 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 			server.logger.Debug("metadata", "setting", key, value, "on", target)
 
 			targetObj.SetMetadata(key, value)
-			notifySubscribers(server, rb.session, target, key, value)
+			notifySubscribers(server, rb.session, targetObj, target, key, value)
 
 			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, "*", value)
 		} else {
 			server.logger.Debug("metadata", "deleting", key, "on", target)
+			// TODO check success or failure here
 			targetObj.DeleteMetadata(key)
-			notifySubscribers(server, rb.session, target, key, "")
+			notifySubscribers(server, rb.session, targetObj, target, key, "")
 
 			rb.Add(nil, server.name, RPL_KEYNOTSET, client.Nick(), target, key, client.t("Key deleted"))
 		}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3155,7 +3155,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 			return
 		}
 
-		if !metadataCanIEditThisKey(client, target, key) {
+		if !metadataCanIEditThisKey(client, targetObj, key) {
 			noKeyPerms(key)
 			return
 		}
@@ -3192,6 +3192,11 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 		}
 
 	case "get":
+		if !metadataCanISeeThisTarget(client, targetObj) {
+			noKeyPerms("*")
+			return
+		}
+
 		batchId := rb.StartNestedBatch("metadata")
 		defer rb.EndNestedBatch(batchId)
 
@@ -3224,7 +3229,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 		}
 
 	case "clear":
-		if !metadataCanIEditThisTarget(client, target) {
+		if !metadataCanIEditThisTarget(client, targetObj) {
 			invalidTarget()
 			return
 		}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3175,7 +3175,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 				return
 			}
 
-			maxKeys := server.Config().Metadata.MaxKeys
+			maxKeys := config.Metadata.MaxKeys
 			isSelf := targetClient != nil && client == targetClient
 
 			if isSelf && maxKeys > 0 && targetObj.CountMetadata() >= maxKeys {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3191,7 +3191,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 				notifySubscribers(server, rb.session, targetObj, target, key, value)
 			}
 			// echo the value to the client whether or not there was a real update
-			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, "*", value)
+			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), target, key, "*", value)
 		} else {
 			if updated := targetObj.DeleteMetadata(key); updated {
 				notifySubscribers(server, rb.session, targetObj, target, key, "")
@@ -3222,7 +3222,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 			}
 
 			visibility := "*"
-			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, visibility, val)
+			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), target, key, visibility, val)
 		}
 
 	case "list":
@@ -3241,7 +3241,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 		for key, val := range values {
 			visibility := "*"
-			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, visibility, val)
+			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), target, key, visibility, val)
 		}
 
 	case "sub":

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3196,6 +3196,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 			if updated := targetObj.DeleteMetadata(key); updated {
 				notifySubscribers(server, rb.session, targetObj, target, key, "")
 			}
+			// acknowledge to the client whether or not there was a real update
 			rb.Add(nil, server.name, RPL_KEYNOTSET, client.Nick(), target, key, client.t("Key deleted"))
 		}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3112,9 +3112,6 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 	subcommand := strings.ToLower(msg.Params[1])
 
-	invalidTarget := func() {
-		rb.Add(nil, server.name, "FAIL", "METADATA", "INVALID_TARGET", target, client.t("Invalid metadata target"))
-	}
 	noKeyPerms := func(key string) {
 		rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_NO_PERMISSION", target, key, client.t("You do not have permission to perform this action"))
 	}
@@ -3140,7 +3137,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 		}
 	}
 	if targetObj == nil {
-		invalidTarget()
+		rb.Add(nil, server.name, "FAIL", "METADATA", "INVALID_TARGET", target, client.t("Invalid metadata target"))
 		return
 	}
 
@@ -3229,7 +3226,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 	case "clear":
 		if !metadataCanIEditThisTarget(client, targetObj) {
-			invalidTarget()
+			noKeyPerms("*")
 			return
 		}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3246,7 +3246,12 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 	case "sub":
 		keys := msg.Params[2:]
-		// TODO validate key names here
+		for _, key := range keys {
+			if metadataKeyIsEvil(key) {
+				rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_INVALID", utils.SafeErrorParam(key), client.t("Invalid key name"))
+				return
+			}
+		}
 		added, err := rb.session.SubscribeTo(keys...)
 		if err == errMetadataTooManySubs {
 			bad := keys[len(added)] // get the key that broke the camel's back

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3226,16 +3226,7 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 		}
 
 	case "list":
-		values := targetObj.ListMetadata()
-
-		batchId := rb.StartNestedBatch("metadata")
-		defer rb.EndNestedBatch(batchId)
-
-		for key, val := range values {
-			visibility := "*"
-
-			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, visibility, val)
-		}
+		playMetadataList(rb, client.Nick(), target, targetObj.ListMetadata())
 
 	case "clear":
 		if !metadataCanIEditThisTarget(client, targetObj) {
@@ -3304,6 +3295,16 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 	}
 
 	return
+}
+
+func playMetadataList(rb *ResponseBuffer, nick, target string, values map[string]string) {
+	batchId := rb.StartNestedBatch("metadata")
+	defer rb.EndNestedBatch(batchId)
+
+	for key, val := range values {
+		visibility := "*"
+		rb.Add(nil, rb.session.client.server.name, RPL_KEYVALUE, nick, target, key, visibility, val)
+	}
 }
 
 // REHASH

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3102,22 +3102,21 @@ func markReadHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 // METADATA <target> <subcommand> [<and so on>...]
 func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) (exiting bool) {
-	originalTarget := msg.Params[0]
-	target := originalTarget
+	target := msg.Params[0]
 
 	config := server.Config()
 	if !config.Metadata.Enabled {
-		rb.Add(nil, server.name, "FAIL", "METADATA", "FORBIDDEN", originalTarget, "Metadata is disabled on this server")
+		rb.Add(nil, server.name, "FAIL", "METADATA", "FORBIDDEN", target, "Metadata is disabled on this server")
 		return
 	}
 
 	subcommand := strings.ToLower(msg.Params[1])
 
 	invalidTarget := func() {
-		rb.Add(nil, server.name, "FAIL", "METADATA", "INVALID_TARGET", originalTarget, client.t("Invalid metadata target"))
+		rb.Add(nil, server.name, "FAIL", "METADATA", "INVALID_TARGET", target, client.t("Invalid metadata target"))
 	}
 	noKeyPerms := func(key string) {
-		rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_NO_PERMISSION", originalTarget, key, client.t("You do not have permission to perform this action"))
+		rb.Add(nil, server.name, "FAIL", "METADATA", "KEY_NO_PERMISSION", target, key, client.t("You do not have permission to perform this action"))
 	}
 
 	if target == "*" {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3189,16 +3189,16 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 			server.logger.Debug("metadata", "setting", key, value, "on", target)
 
-			targetObj.SetMetadata(key, value)
-			notifySubscribers(server, rb.session, targetObj, target, key, value)
-
+			if updated := targetObj.SetMetadata(key, value); updated {
+				notifySubscribers(server, rb.session, targetObj, target, key, value)
+			}
+			// echo the value to the client whether or not there was a real update
 			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, "*", value)
 		} else {
 			server.logger.Debug("metadata", "deleting", key, "on", target)
-			// TODO check success or failure here
-			targetObj.DeleteMetadata(key)
-			notifySubscribers(server, rb.session, targetObj, target, key, "")
-
+			if updated := targetObj.DeleteMetadata(key); updated {
+				notifySubscribers(server, rb.session, targetObj, target, key, "")
+			}
 			rb.Add(nil, server.name, RPL_KEYNOTSET, client.Nick(), target, key, client.t("Key deleted"))
 		}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3187,15 +3187,12 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 				return
 			}
 
-			server.logger.Debug("metadata", "setting", key, value, "on", target)
-
 			if updated := targetObj.SetMetadata(key, value); updated {
 				notifySubscribers(server, rb.session, targetObj, target, key, value)
 			}
 			// echo the value to the client whether or not there was a real update
 			rb.Add(nil, server.name, RPL_KEYVALUE, client.Nick(), originalTarget, key, "*", value)
 		} else {
-			server.logger.Debug("metadata", "deleting", key, "on", target)
 			if updated := targetObj.DeleteMetadata(key); updated {
 				notifySubscribers(server, rb.session, targetObj, target, key, "")
 			}
@@ -3257,7 +3254,6 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 	case "sub":
 		keys := msg.Params[2:]
-		server.logger.Debug("metadata", client.nick, "has subscrumbled to", strings.Join(keys, ", "))
 		added, err := rb.session.SubscribeTo(keys...)
 		if err == errMetadataTooManySubs {
 			bad := keys[len(added)] // get the key that broke the camel's back
@@ -3274,7 +3270,6 @@ func metadataHandler(server *Server, client *Client, msg ircmsg.Message, rb *Res
 
 	case "unsub":
 		keys := msg.Params[2:]
-		server.logger.Debug("metadata", client.nick, "has UNsubscrumbled to", strings.Join(keys, ", "))
 		removed := rb.session.UnsubscribeFrom(keys...)
 
 		lineLength := MaxLineLen - len(server.name) - len(RPL_METADATAUNSUBOK) - len(client.Nick()) - 10

--- a/irc/help.go
+++ b/irc/help.go
@@ -342,7 +342,7 @@ specification.`,
 	},
 	"metadata": {
 		text: `METADATA <target> <subcommand> [<everything else>...]
-		
+
 Retrieve and meddle with metadata for the given target.
 Have a look at https://ircv3.net/specs/extensions/metadata for interesting technical information.`,
 	},

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -22,9 +22,9 @@ var (
 )
 
 type MetadataHaver = interface {
-	SetMetadata(key string, value string)
+	SetMetadata(key string, value string) (updated bool)
 	GetMetadata(key string) (string, bool)
-	DeleteMetadata(key string)
+	DeleteMetadata(key string) (updated bool)
 	ListMetadata() map[string]string
 	ClearMetadata() map[string]string
 	CountMetadata() int

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -42,7 +42,7 @@ func notifySubscribers(server *Server, session *Session, targetObj MetadataHaver
 		}
 		recipientSessions = maps.Keys(friends)
 	case *Channel:
-		recipientSessions = target.sessionsWithCap(caps.Metadata)
+		recipientSessions = target.sessionsWithCaps(caps.Metadata)
 	default:
 		return // impossible
 	}

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -62,16 +62,13 @@ func broadcastMetadataUpdate(server *Server, sessions iter.Seq[*Session], origin
 }
 
 func syncClientMetadata(server *Server, rb *ResponseBuffer, target *Client) {
-	if len(rb.session.MetadataSubscriptions()) == 0 {
-		return
-	}
-
 	batchId := rb.StartNestedBatch("metadata")
 	defer rb.EndNestedBatch(batchId)
 
+	subs := rb.session.MetadataSubscriptions()
 	values := target.ListMetadata()
 	for k, v := range values {
-		if rb.session.isSubscribedTo(k) {
+		if subs.Has(k) {
 			visibility := "*"
 			rb.Add(nil, server.name, "METADATA", target.Nick(), k, visibility, v)
 		}
@@ -79,16 +76,14 @@ func syncClientMetadata(server *Server, rb *ResponseBuffer, target *Client) {
 }
 
 func syncChannelMetadata(server *Server, rb *ResponseBuffer, target *Channel) {
-	if len(rb.session.MetadataSubscriptions()) == 0 {
-		return
-	}
-
 	batchId := rb.StartNestedBatch("metadata")
 	defer rb.EndNestedBatch(batchId)
 
+	subs := rb.session.MetadataSubscriptions()
+
 	values := target.ListMetadata()
 	for k, v := range values {
-		if rb.session.isSubscribedTo(k) {
+		if subs.Has(k) {
 			visibility := "*"
 			rb.Add(nil, server.name, "METADATA", target.Name(), k, visibility, v)
 		}
@@ -97,7 +92,7 @@ func syncChannelMetadata(server *Server, rb *ResponseBuffer, target *Channel) {
 	for _, client := range target.Members() {
 		values := client.ListMetadata()
 		for k, v := range values {
-			if rb.session.isSubscribedTo(k) {
+			if subs.Has(k) {
 				visibility := "*"
 				rb.Add(nil, server.name, "METADATA", client.Nick(), k, visibility, v)
 			}

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -117,48 +117,29 @@ func metadataKeyIsEvil(key string) bool {
 		metadataEvilCharsRegexp.MatchString(key) // key can't contain the stuff it can't contain
 }
 
-func metadataCanIEditThisKey(client *Client, target string, _ string) bool {
-	if !metadataCanIEditThisTarget(client, target) { // you can't edit keys on targets you can't edit.
-		return false
-	}
-
-	// todo: we don't actually do anything regarding visibility yet so there's not much to do here
-
-	return true
+func metadataCanIEditThisKey(client *Client, targetObj MetadataHaver, key string) bool {
+	// no key-specific logic as yet
+	return metadataCanIEditThisTarget(client, targetObj)
 }
 
-func metadataCanIEditThisTarget(client *Client, target string) bool {
-	if !metadataCanISeeThisTarget(client, target) { // you can't edit what you can't see. a wise man told me this once
-		return false
+func metadataCanIEditThisTarget(client *Client, targetObj MetadataHaver) bool {
+	switch target := targetObj.(type) {
+	case *Client:
+		return client == target || client.HasRoleCapabs("metadata")
+	case *Channel:
+		return target.ClientIsAtLeast(client, modes.Operator) || client.HasRoleCapabs("metadata")
+	default:
+		return false // impossible
 	}
-
-	if client.HasRoleCapabs("sajoin") { // sajoin opers can do whatever they want
-		return true
-	}
-
-	if target == client.Nick() { // your right to swing your fist ends where my nose begins
-		return true
-	}
-
-	// if you're a channel operator, knock yourself out
-	channel := client.server.channels.Get(target)
-	if channel != nil && channel.ClientIsAtLeast(client, modes.Operator) {
-		return true
-	}
-
-	return false
 }
 
-func metadataCanISeeThisTarget(client *Client, target string) bool {
-	if client.HasRoleCapabs("sajoin") { // sajoin opers can do whatever they want
+func metadataCanISeeThisTarget(client *Client, targetObj MetadataHaver) bool {
+	switch target := targetObj.(type) {
+	case *Client:
 		return true
+	case *Channel:
+		return target.hasClient(client) || client.HasRoleCapabs("metadata")
+	default:
+		return false // impossible
 	}
-
-	// check if the user is in the channel
-	channel := client.server.channels.Get(target)
-	if channel != nil && !channel.hasClient(client) {
-		return false
-	}
-
-	return true
 }

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -80,21 +80,22 @@ func syncClientMetadata(server *Server, rb *ResponseBuffer, target *Client) {
 	}
 }
 
-func syncChannelMetadata(server *Server, rb *ResponseBuffer, target *Channel) {
+func syncChannelMetadata(server *Server, rb *ResponseBuffer, channel *Channel) {
 	batchId := rb.StartNestedBatch("metadata")
 	defer rb.EndNestedBatch(batchId)
 
 	subs := rb.session.MetadataSubscriptions()
+	chname := channel.Name()
 
-	values := target.ListMetadata()
+	values := channel.ListMetadata()
 	for k, v := range values {
 		if subs.Has(k) {
 			visibility := "*"
-			rb.Add(nil, server.name, "METADATA", target.Name(), k, visibility, v)
+			rb.Add(nil, server.name, "METADATA", chname, k, visibility, v)
 		}
 	}
 
-	for _, client := range target.Members() {
+	for _, client := range channel.Members() {
 		values := client.ListMetadata()
 		for k, v := range values {
 			if subs.Has(k) {

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ergochat/ergo/irc/modes"
 )
 
+const (
+	// metadata key + value need to be relayable on a single IRC RPL_KEYVALUE line
+	maxCombinedMetadataLenBytes = 350
+)
+
 var (
 	errMetadataTooManySubs = errors.New("too many subscriptions")
 	errMetadataNotFound    = errors.New("key not found")

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -21,7 +21,7 @@ var (
 )
 
 type MetadataHaver = interface {
-	SetMetadata(key string, value string) (updated bool)
+	SetMetadata(key string, value string, limit int) (updated bool, err error)
 	GetMetadata(key string) (string, bool)
 	DeleteMetadata(key string) (updated bool)
 	ListMetadata() map[string]string

--- a/irc/metadata.go
+++ b/irc/metadata.go
@@ -5,7 +5,6 @@ import (
 	"iter"
 	"maps"
 	"regexp"
-	"strings"
 
 	"github.com/ergochat/ergo/irc/caps"
 	"github.com/ergochat/ergo/irc/modes"
@@ -109,8 +108,6 @@ func syncChannelMetadata(server *Server, rb *ResponseBuffer, channel *Channel) {
 var metadataEvilCharsRegexp = regexp.MustCompile("[^A-Za-z0-9_./:-]+")
 
 func metadataKeyIsEvil(key string) bool {
-	key = strings.TrimSpace(key) // just in case
-
 	return len(key) == 0 || // key needs to contain stuff
 		key[0] == ':' || // key can't start with a colon
 		metadataEvilCharsRegexp.MatchString(key) // key can't contain the stuff it can't contain

--- a/irc/server.go
+++ b/irc/server.go
@@ -496,6 +496,9 @@ func (server *Server) playRegistrationBurst(session *Session) {
 	if !(rb.session.capabilities.Has(caps.ExtendedISupport) && rb.session.isupportSentPrereg) {
 		server.RplISupport(c, rb)
 	}
+	if session.capabilities.Has(caps.Metadata) && c.AlwaysOn() {
+		playMetadataList(rb, d.nick, d.nick, c.ListMetadata())
+	}
 	if d.account != "" && session.capabilities.Has(caps.Persistence) {
 		reportPersistenceStatus(c, rb, false)
 	}

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -1064,10 +1064,9 @@ metadata:
     # can clients store metadata?
     enabled: true
     # how many keys can a client subscribe to?
-    # set to 0 to disable subscriptions or -1 to allow unlimited subscriptions.
     max-subs: 100
-    # how many keys can a user store about themselves? set to -1 to allow unlimited keys.
-    max-keys: 1000
+    # how many keys can be stored per entity?
+    max-keys: 100
 
 # experimental support for mobile push notifications
 # see the manual for potential security, privacy, and performance implications.

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -695,6 +695,7 @@ oper-classes:
             - "history"      # modify or delete history messages
             - "defcon"       # use the DEFCON command (restrict server capabilities)
             - "massmessage"  # message all users on the server
+            - "metadata"     # modify arbitrary metadata on channels and users
 
 # ircd operators
 opers:

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -1058,12 +1058,15 @@ history:
 # e.g., ERGO__SERVER__MAX_SENDQ=128k. see the manual for more details.
 allow-environment-overrides: true
 
-# experimental IRC metadata support for setting key/value data on channels and nicknames.
+# metadata support for setting key/value data on channels and nicknames.
 metadata:
-    # can clients use the metadata command?
+    # can clients store metadata?
     enabled: true
     # how many keys can a client subscribe to?
-    max-subs: 1000
+    # set to 0 to disable subscriptions or -1 to allow unlimited subscriptions.
+    max-subs: 100
+    # how many keys can a user store about themselves? set to -1 to allow unlimited keys.
+    max-keys: 1000
 
 # experimental support for mobile push notifications
 # see the manual for potential security, privacy, and performance implications.


### PR DESCRIPTION
cc @thatcher-gaming, possibly of interest (no pressure)

This addresses some of #2274. One area where I am not satisfied is how the spec interacts with persistent clients ("always-on"):

1. I don't like the aspect of the current spec where it does an edge-triggered metadata sync on requesting the cap; I generally prefer explicit client commands to having `CAP REQ` trigger side effects
2. Instead, for always-on clients, we preemptively send them their own metadata in the registration burst, between 005 and RPL_ENDOFMOTD / ERR_NOMOTD. (In the spirit of the current spec, we might want to send even non-always-on clients that have requested the cap an empty batch here? Although if the batch is empty, you don't know what entity the empty batch is talking about --- really you need labeled-response even for a normal `METADATA LIST` command.)
3. For always-on clients, we would like to accept `SUB` during connection registration (since subs are per-session and they they take effect immediately after connection registration) but we do not necessarily want to accept `SET`, which could overwrite metadata that is more authoritative than the client's cached view
4. What is the use case for `SET` during connection registration for anyone?

I'm tempted to say that `before-connect` should take a value, either `*` for unrestricted or `sub` for subscription-related commands only.