### PR TITLE
fix some documentation

### DIFF
--- a/irc/help.go
+++ b/irc/help.go
@@ -238,11 +238,10 @@ Get an explanation of <argument>, or "index" for a list of help topics.`,
 	"history": {
 		text: `HISTORY <target> [limit]
 
-Replay message history. <target> can be a channel name, "me" to replay direct
-message history, or a nickname to replay another client's direct message
-history (they must be logged into the same account as you). [limit] can be
-either an integer (the maximum number of messages to replay), or a time
-duration like 10m or 1h (the time window within which to replay messages).`,
+Replay message history. <target> can be a channel name or a nickname you have
+direct message history with. [limit] can be either an integer (the maximum
+number of messages to replay), or a time duration like 10m or 1h (the time
+window within which to replay messages).`,
 	},
 	"info": {
 		text: `INFO

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -73,7 +73,7 @@ var globalCasemappingSetting Casemapping = CasemappingPRECIS
 
 // XXX analogous unsynchronized global variable controlling utf8 validation
 // if this is off, you get the traditional IRC behavior (relaying any valid RFC1459
-// octets) and invalid utf8 messages are silently dropped for websocket clients only.
+// octets), and websocket listeners are disabled.
 // if this is on, invalid utf8 inputs get a FAIL reply.
 var globalUtf8EnforcementSetting bool
 


### PR DESCRIPTION
Fix a couple things that were documented incorrectly.

This fixes #2278. I don't think it's worth restoring `HISTORY me` or `HISTORY *` since it would require some refactoring and I see no evidence that the feature is useful.