### PR TITLE
fix validation of web push URLs

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3934,6 +3934,7 @@ func webpushHandler(server *Server, client *Client, msg ircmsg.Message, rb *Resp
 
 	if err := webpush.SanityCheckWebPushEndpoint(endpoint); err != nil {
 		rb.Add(nil, server.name, "FAIL", "WEBPUSH", "INVALID_PARAMS", subcommand, client.t("Invalid web push URL"))
+		return false
 	}
 
 	switch subcommand {


### PR DESCRIPTION
They are validated by test message, but it would have been possible to add an http url.

If an http url was added, it's still possible to remove it via NS PUSH DELETE.