### PR TITLE
changes to OPER command

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -358,6 +358,10 @@ server:
     secure-nets:
         # - "10.0.0.0/8"
 
+    # allow attempts to OPER with a password at most this often. default to
+    # 10 seconds when unset.
+    oper-throttle: 10s
+
     # Ergo will write files to disk under certain circumstances, e.g.,
     # CPU profiling or data export. by default, these files will be written
     # to the working directory. set this to customize:

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -527,7 +527,7 @@ If your client or bot is failing to connect to Ergo, here are some things to che
 
 ## Why can't I oper?
 
-If you try to oper unsuccessfully, Ergo will disconnect you from the network. If you're unable to oper, here are some things to double-check:
+If your `OPER` command fails, check your server logs for more information. Here are some general issues to double-check:
 
 1. Did you correctly generate the hashed password with `ergo genpasswd`?
 1. Did you add the password hash to the correct config file, then save the file?

--- a/irc/client.go
+++ b/irc/client.go
@@ -189,6 +189,8 @@ type Session struct {
 	fakelag              Fakelag
 	deferredFakelagCount int
 
+	lastOperAttempt time.Time
+
 	certfp     string
 	peerCerts  []*x509.Certificate
 	sasl       saslStatus

--- a/irc/config.go
+++ b/irc/config.go
@@ -599,6 +599,7 @@ type Config struct {
 		Cloaks                   cloaks.CloakConfig              `yaml:"ip-cloaking"`
 		SecureNetDefs            []string                        `yaml:"secure-nets"`
 		secureNets               []net.IPNet
+		OperThrottle             time.Duration `yaml:"oper-throttle"`
 		supportedCaps            *caps.Set
 		supportedCapsWithoutSTS  *caps.Set
 		capValues                caps.Values
@@ -1478,6 +1479,10 @@ func LoadConfig(filename string) (config *Config, err error) {
 		config.Server.capValues[caps.SASL] = strings.Join(saslCapValues, ",")
 	} else {
 		config.Server.supportedCaps.Disable(caps.SASL)
+	}
+
+	if config.Server.OperThrottle <= 0 {
+		config.Server.OperThrottle = 10 * time.Second
 	}
 
 	if err := config.Accounts.OAuth2.Postprocess(); err != nil {

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -330,6 +330,10 @@ server:
     secure-nets:
         # - "10.0.0.0/8"
 
+    # allow attempts to OPER with a password at most this often. default to
+    # 10 seconds when unset.
+    oper-throttle: 10s
+
     # Ergo will write files to disk under certain circumstances, e.g.,
     # CPU profiling or data export. by default, these files will be written
     # to the working directory. set this to customize:


### PR DESCRIPTION
* Impose a throttle on OPER attempts regardless of whether they caused a password check.
* Never disconnect the client on a failed attempt, even if there was a password check.
* Change error numeric to ERR_NOOPERHOST
* Explicit information about the failure in the server log (copying Insp)

Fixes #2296.