### PR TITLE
pin Alpine to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## build ergo binary
-FROM docker.io/golang:1.25-alpine AS build-env
+FROM docker.io/golang:1.25-alpine3.22 AS build-env
 
 RUN apk upgrade -U --force-refresh --no-cache && apk add --no-cache --purge --clean-protected -l -u make git
 
@@ -16,7 +16,7 @@ RUN sed -i 's/^\(\s*\)\"127.0.0.1:6667\":.*$/\1":6667":/' /go/src/github.com/erg
 RUN make install
 
 ## build ergo container
-FROM docker.io/alpine:3.19
+FROM docker.io/alpine:3.22
 
 # metadata
 LABEL maintainer="Daniel Oaks <daniel@danieloaks.net>,Daniel Thamdrup <dallemon@protonmail.com>" \


### PR DESCRIPTION
* Upgrade the production image from 3.19 to 3.22 (3.19 went EOL 2025-11-01)
* Downgrade the build image to 3.22 (3.23 is buggy, see #2305)