### PR TITLE
update bcrypt-cost comments to also add highest possible value

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -425,7 +425,7 @@ accounts:
             max-attempts: 30
 
         # this is the bcrypt cost we'll use for account passwords
-        # (note that 4 is the lowest value allowed by the bcrypt library)
+        # (note that 4 is the lowest and 31 is the highest value allowed by the bcrypt library)
         bcrypt-cost: 4
 
         # length of time a user has to verify their account before it can be re-registered

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -397,7 +397,7 @@ accounts:
             max-attempts: 30
 
         # this is the bcrypt cost we'll use for account passwords
-        # (note that 4 is the lowest value allowed by the bcrypt library)
+        # (note that 4 is the lowest and 31 is the highest value allowed by the bcrypt library)
         bcrypt-cost: 4
 
         # length of time a user has to verify their account before it can be re-registered


### PR DESCRIPTION
While configuring a new server I mistakenly set `bcrypt-cost` in my server config to something much higher than allowed. 

The error propagation for the passphrase checking logic returns the same error code for multiple paths out of that logic, so it took a good while to work out exactly why new account registration was failing after my misconfiguration.

Hopefully adding a note to the comments above `bcrypt-cost` in the config examples will help others discover their mistake in the same situation.