### PR TITLE
fix (*SQLite).ListChannels

### DIFF
--- a/irc/sqlite/history.go
+++ b/irc/sqlite/history.go
@@ -998,7 +998,7 @@ func (s *SQLite) ListChannels(cfchannels []string) (results []history.TargetList
 	results = make([]history.TargetListing, 0, len(cfchannels))
 	for _, chname := range cfchannels {
 		var nanotime int64
-		err = s.selectChannelTime.QueryRowContext(ctx, chname).Scan(&nanotime)
+		err := s.selectChannelTime.QueryRowContext(ctx, chname).Scan(&nanotime)
 		if err == sql.ErrNoRows {
 			continue // channel has no messages, skip it
 		}


### PR DESCRIPTION
If the final channel we attempted to list had no messages, sql.ErrNoRows would be returned as the error for the entire function, which would prevent any channels from appearing in the targets list.