### PR TITLE
fix handling of invalid API bearer tokens

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -1032,12 +1032,12 @@ func (config *Config) processAPI() (err error) {
 		return errors.New("config.api.enabled is true, but listener address is empty")
 	}
 
-	config.API.bearerTokenBytes = make([][]byte, len(config.API.BearerTokens))
-	for i, tok := range config.API.BearerTokens {
+	config.API.bearerTokenBytes = make([][]byte, 0, len(config.API.BearerTokens))
+	for _, tok := range config.API.BearerTokens {
 		if tok == "" || tok == "example" {
 			continue
 		}
-		config.API.bearerTokenBytes[i] = []byte(tok)
+		config.API.bearerTokenBytes = append(config.API.bearerTokenBytes, []byte(tok))
 	}
 
 	var tlsConfig *tls.Config


### PR DESCRIPTION
Found using Claude Opus 4.6, fixed manually. The intent in #2231 was to ignore tokens that were blank or `example`. Instead, config validation effectively normalized `example` to the empty string, allowing authentication with an empty bearer token.

IMO this doesn't require a pointfix since it only affects obvious misconfigurations of Ergo (we intended to provide a safeguard against those misconfigurations, but failed).