### PR TITLE
fix missing read permissions checks for METADATA

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3269,6 +3269,16 @@ func metadataRegisteredHandler(client *Client, config *Config, subcommand string
 			}
 		}
 
+	case "clear":
+		if !metadataCanIEditThisTarget(client, targetObj) {
+			noKeyPerms("*")
+			return
+		}
+
+		values := targetObj.ClearMetadata()
+
+		playMetadataList(rb, client.Nick(), target, values)
+
 	case "get":
 		if !metadataCanISeeThisTarget(client, targetObj) {
 			noKeyPerms("*")
@@ -3295,19 +3305,19 @@ func metadataRegisteredHandler(client *Client, config *Config, subcommand string
 		}
 
 	case "list":
-		playMetadataList(rb, client.Nick(), target, targetObj.ListMetadata())
-
-	case "clear":
-		if !metadataCanIEditThisTarget(client, targetObj) {
+		if !metadataCanISeeThisTarget(client, targetObj) {
 			noKeyPerms("*")
 			return
 		}
 
-		values := targetObj.ClearMetadata()
-
-		playMetadataList(rb, client.Nick(), target, values)
+		playMetadataList(rb, client.Nick(), target, targetObj.ListMetadata())
 
 	case "sync":
+		if !metadataCanISeeThisTarget(client, targetObj) {
+			noKeyPerms("*")
+			return
+		}
+
 		if targetChannel != nil {
 			syncChannelMetadata(server, rb, targetChannel)
 		}


### PR DESCRIPTION
These were incorrectly refactored out in #2277. Also group the two write subcommands together, then the three read subcommands.