### PR TITLE
first pass at draft/AUTHTOKEN support

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -663,6 +663,9 @@ accounts:
                 # if a claim is formatted as an email address, require it to have the following domain,
                 # and then strip off the domain and use the local-part as the account name:
                 #strip-domain: "example.com"
+                # optional list of `aud` claims that are acceptable
+                # (if omitted, the aud claim is not validated):
+                #validate-aud: ["irc.mydomain.com"]
 
 # channel options
 channels:

--- a/default.yaml
+++ b/default.yaml
@@ -1027,16 +1027,34 @@ extjwt:
     # # default service config (for `EXTJWT #channel`).
     # # expiration time for the token:
     # expiration: 45s
-    # # you can configure tokens to be signed either with HMAC and a symmetric secret:
-    # secret: "65PHvk0K1_sM-raTsCEhatVkER_QD8a0zVV8gG2EWcI"
-    # # or with an RSA private key:
-    # #rsa-private-key-file: "extjwt.pem"
+    # algorithm: "hmac" # either 'hmac', 'rsa', or 'eddsa' (ed25519)
+    # # hmac takes a symmetric key, rsa and eddsa take PEM-encoded public keys;
+    # # either way, the key can be specified either as a YAML string:
+    # key: "nANiZ1De4v6WnltCHN2H7Q"
+    # # or as a path to the file containing the key:
+    # #key-file: "jwt_pubkey.pem"
 
     # # named services (for `EXTJWT #channel service_name`):
     # services:
     #     "jitsi":
     #         expiration: 30s
-    #         secret: "qmamLKDuOzIzlO8XqsGGewei_At11lewh6jtKfSTbkg"
+    #         algorithm: "hmac"
+    #         key: "qmamLKDuOzIzlO8XqsGGewei_At11lewh6jtKfSTbkg"
+
+# experimental draft/AUTHTOKEN mechanism
+authtoken:
+    enabled: false
+
+    # only these IPs can verify tokens
+    verification-ip-whitelist:
+        - "localhost"
+
+    #services:
+    #   "FILEHOST":
+    #       expiration: 5m
+    #       url: "https://example.com/filehost"
+    #       algorithm: "eddsa"
+    #       key: "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIHfpO1x835o9NIQA1kBkN7/Myd6wqE/m/EYJUHBC18hW\n-----END PRIVATE KEY-----"
 
 # history message storage: this is used by CHATHISTORY, HISTORY, znc.in/playback,
 # various autoreplay features, and the resume extension

--- a/default.yaml
+++ b/default.yaml
@@ -1031,11 +1031,11 @@ extjwt:
     # # expiration time for the token:
     # expiration: 45s
     # algorithm: "hmac" # either 'hmac', 'rsa', or 'eddsa' (ed25519)
-    # # hmac takes a symmetric key, rsa and eddsa take PEM-encoded public keys;
+    # # hmac takes a symmetric key, rsa and eddsa take PEM-encoded private keys;
     # # either way, the key can be specified either as a YAML string:
     # key: "nANiZ1De4v6WnltCHN2H7Q"
     # # or as a path to the file containing the key:
-    # #key-file: "jwt_pubkey.pem"
+    # #key-file: "jwt_privkey.pem"
 
     # # named services (for `EXTJWT #channel service_name`):
     # services:

--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -243,6 +243,13 @@ CAPDEFS = [
         url="https://ircv3.net/specs/extensions/metadata",
         standard="draft IRCv3",
     ),
+    CapDef(
+        identifier="AuthToken",
+        name="draft/authtoken",
+        url="https://github.com/ircv3/ircv3-specifications/pull/602",
+        standard="proposed IRCv3",
+    ),
+
 
 ]
 

--- a/irc/caps/constants.go
+++ b/irc/caps/constants.go
@@ -66,6 +66,9 @@ const (
 	ChathistoryTargetsBatchType   = "draft/chathistory-targets"
 	ExtendedISupportBatchType     = "draft/isupport"
 	ChathistoryEndOfPaginationTag = "draft/chathistory-end"
+
+	// authtoken draft: https://github.com/ircv3/ircv3-specifications/pull/602
+	AuthTokenBatchName = "draft/authtoken"
 )
 
 func init() {

--- a/irc/caps/constants.go
+++ b/irc/caps/constants.go
@@ -68,7 +68,8 @@ const (
 	ChathistoryEndOfPaginationTag = "draft/chathistory-end"
 
 	// authtoken draft: https://github.com/ircv3/ircv3-specifications/pull/602
-	AuthTokenBatchName = "draft/authtoken"
+	AuthTokenBatchType = "draft/authtoken"
+	AuthToken005       = "draft/AUTHTOKEN"
 )
 
 func init() {

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -7,7 +7,7 @@ package caps
 
 const (
 	// number of recognized capabilities:
-	numCapabs = 38
+	numCapabs = 39
 	// length of the uint32 array that represents the bitset:
 	bitsetLen = 2
 )
@@ -40,6 +40,10 @@ const (
 	// AccountRegistration is the draft IRCv3 capability named "draft/account-registration":
 	// https://github.com/ircv3/ircv3-specifications/pull/435
 	AccountRegistration Capability = iota
+
+	// AuthToken is the proposed IRCv3 capability named "draft/authtoken":
+	// https://github.com/ircv3/ircv3-specifications/pull/602
+	AuthToken Capability = iota
 
 	// ChannelRename is the draft IRCv3 capability named "draft/channel-rename":
 	// https://ircv3.net/specs/extensions/channel-rename
@@ -176,6 +180,7 @@ var (
 		"cap-notify",
 		"chghost",
 		"draft/account-registration",
+		"draft/authtoken",
 		"draft/channel-rename",
 		"draft/chathistory",
 		"draft/event-playback",

--- a/irc/client.go
+++ b/irc/client.go
@@ -220,6 +220,8 @@ type Session struct {
 
 	metadataSubscriptions utils.HashSet[string]
 	metadataPreregVals    map[string]string
+
+	authTokenBuffer []byte // goroutine-local: TOKEN VALIDATE buffer
 }
 
 // MultilineBatch tracks the state of a client-to-server multiline batch.
@@ -402,6 +404,7 @@ func (server *Server) RunClient(conn IRCConn, cookies []RequestCookie) {
 		connID:     connID,
 		cookies:    cookies,
 	}
+	cookies = nil
 	session.sasl.Initialize()
 	client.sessions = []*Session{session}
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -214,14 +214,14 @@ type Session struct {
 	zncPlaybackTimes      *zncPlaybackTimes
 	autoreplayMissedSince time.Time
 
-	batch MultilineBatch
+	multilineBatch MultilineBatch
 
 	webPushEndpoint string // goroutine-local: web push endpoint registered by the current session
 
 	metadataSubscriptions utils.HashSet[string]
 	metadataPreregVals    map[string]string
 
-	authTokenBuffer []byte // goroutine-local: TOKEN VALIDATE buffer
+	tokenValidateBatch *TokenValidateBatch
 }
 
 // MultilineBatch tracks the state of a client-to-server multiline batch.
@@ -235,13 +235,21 @@ type MultilineBatch struct {
 	tags          map[string]string
 }
 
+type TokenValidateBatch struct {
+	label         string
+	responseLabel string
+	service       string
+	url           string
+	buf           strings.Builder
+}
+
 // Starts a multiline batch, failing if there's one already open
 func (s *Session) StartMultilineBatch(label, target, responseLabel string, tags map[string]string) (err error) {
-	if s.batch.label != "" {
+	if s.multilineBatch.label != "" {
 		return errInvalidMultilineBatch
 	}
 
-	s.batch.label, s.batch.target, s.batch.responseLabel, s.batch.tags = label, target, responseLabel, tags
+	s.multilineBatch.label, s.multilineBatch.target, s.multilineBatch.responseLabel, s.multilineBatch.tags = label, target, responseLabel, tags
 	s.fakelag.Suspend()
 	return
 }
@@ -249,8 +257,8 @@ func (s *Session) StartMultilineBatch(label, target, responseLabel string, tags 
 // Closes a multiline batch unconditionally; returns the batch and whether
 // it was validly terminated (pass "" as the label if you don't care about the batch)
 func (s *Session) EndMultilineBatch(label string) (batch MultilineBatch, err error) {
-	batch = s.batch
-	s.batch = MultilineBatch{}
+	batch = s.multilineBatch
+	s.multilineBatch = MultilineBatch{}
 	s.fakelag.Unsuspend()
 
 	// heuristics to estimate how much data they used while fakelag was suspended

--- a/irc/client.go
+++ b/irc/client.go
@@ -239,7 +239,6 @@ type TokenValidateBatch struct {
 	label         string
 	responseLabel string
 	service       string
-	url           string
 	buf           strings.Builder
 }
 

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -319,10 +319,6 @@ func init() {
 		"SUMMON": {
 			handler: summonHandler,
 		},
-		"TAGMSG": {
-			handler:   messageHandler,
-			minParams: 1,
-		},
 		"QUIT": {
 			handler:      quitHandler,
 			usablePreReg: true,
@@ -337,9 +333,18 @@ func init() {
 			minParams: 0,
 			capabs:    []string{"rehash"},
 		},
+		"TAGMSG": {
+			handler:   messageHandler,
+			minParams: 1,
+		},
 		"TIME": {
 			handler:   timeHandler,
 			minParams: 0,
+		},
+		"TOKEN": {
+			handler:      tokenHandler,
+			minParams:    1,
+			usablePreReg: true,
 		},
 		"TOPIC": {
 			handler:   topicHandler,

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -11,11 +11,10 @@ import (
 
 // Command represents a command accepted from a client.
 type Command struct {
-	handler        func(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool
-	usablePreReg   bool
-	allowedInBatch bool // allowed in client-to-server batches
-	minParams      int
-	capabs         []string
+	handler      func(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool
+	usablePreReg bool
+	minParams    int
+	capabs       []string
 }
 
 // resolveCommand returns the command to execute in response to a user input line.
@@ -56,9 +55,15 @@ func (cmd *Command) Run(server *Server, client *Client, session *Session, msg ir
 			rb.Add(nil, server.name, ERR_NEEDMOREPARAMS, client.Nick(), msg.Command, rb.target.t("Not enough parameters"))
 			return false
 		}
-		if session.batch.label != "" && !cmd.allowedInBatch {
+		// C2S batch restrictions, custom per C2S batch type:
+		if session.multilineBatch.label != "" && !(msg.Command == "BATCH" || msg.Command == "PRIVMSG" || msg.Command == "NOTICE") {
 			rb.Add(nil, server.name, "FAIL", "BATCH", "MULTILINE_INVALID", client.t("Command not allowed during a multiline batch"))
 			session.EndMultilineBatch("")
+			return false
+		}
+		if session.tokenValidateBatch != nil && !(msg.Command == "BATCH" || msg.Command == "TOKEN") {
+			rb.Add(nil, server.name, "FAIL", "BATCH", "INVALID_PARAMS", client.t("Command not allowed during a TOKEN VALIDATE batch"))
+			session.tokenValidateBatch = nil
 			return false
 		}
 
@@ -112,9 +117,8 @@ func init() {
 			minParams:    0,
 		},
 		"BATCH": {
-			handler:        batchHandler,
-			minParams:      1,
-			allowedInBatch: true,
+			handler:   batchHandler,
+			minParams: 1,
 		},
 		"CAP": {
 			handler:      capHandler,
@@ -236,9 +240,8 @@ func init() {
 			minParams:    1,
 		},
 		"NOTICE": {
-			handler:        messageHandler,
-			minParams:      2,
-			allowedInBatch: true,
+			handler:   messageHandler,
+			minParams: 2,
 		},
 		"NPC": {
 			handler:   npcHandler,
@@ -276,18 +279,33 @@ func init() {
 			minParams:    1,
 		},
 		"PRIVMSG": {
-			handler:        messageHandler,
-			minParams:      2,
-			allowedInBatch: true,
+			handler:   messageHandler,
+			minParams: 2,
 		},
-		"RELAYMSG": {
-			handler:   relaymsgHandler,
-			minParams: 3,
+		"QUIT": {
+			handler:      quitHandler,
+			usablePreReg: true,
+			minParams:    0,
+		},
+		"REDACT": {
+			handler:   redactHandler,
+			minParams: 2,
 		},
 		"REGISTER": {
 			handler:      registerHandler,
 			minParams:    3,
 			usablePreReg: true,
+		},
+
+		"REHASH": {
+			handler:   rehashHandler,
+			minParams: 0,
+			capabs:    []string{"rehash"},
+		},
+
+		"RELAYMSG": {
+			handler:   relaymsgHandler,
+			minParams: 3,
 		},
 		"RENAME": {
 			handler:   renameHandler,
@@ -318,20 +336,6 @@ func init() {
 		},
 		"SUMMON": {
 			handler: summonHandler,
-		},
-		"QUIT": {
-			handler:      quitHandler,
-			usablePreReg: true,
-			minParams:    0,
-		},
-		"REDACT": {
-			handler:   redactHandler,
-			minParams: 2,
-		},
-		"REHASH": {
-			handler:   rehashHandler,
-			minParams: 0,
-			capabs:    []string{"rehash"},
 		},
 		"TAGMSG": {
 			handler:   messageHandler,

--- a/irc/config.go
+++ b/irc/config.go
@@ -1948,7 +1948,7 @@ func (config *Config) generateISupport() (err error) {
 	}
 
 	if config.AuthToken.Enabled {
-		isupport.Add("draft/AUTHTOKEN", "")
+		isupport.Add(caps.AuthToken005, "")
 	}
 
 	for key, value := range config.Server.AdditionalISupport {

--- a/irc/config.go
+++ b/irc/config.go
@@ -627,6 +627,8 @@ type Config struct {
 		Services map[string]jwt.JwtServiceConfig `yaml:"services"`
 	}
 
+	AuthToken jwt.AuthTokensConfig `yaml:"authtoken"`
+
 	Languages struct {
 		Enabled bool
 		Path    string
@@ -1005,7 +1007,7 @@ func (config *Config) processExtjwt() (err error) {
 	// first process the default service, which may be disabled
 	err = config.Extjwt.Default.Postprocess()
 	if err != nil {
-		return
+		return fmt.Errorf("invalid extjwt config for default service: %w", err)
 	}
 	// now process the named services. it is an error if any is disabled
 	// also, normalize the service names to lowercase
@@ -1013,7 +1015,7 @@ func (config *Config) processExtjwt() (err error) {
 	for service, sConf := range config.Extjwt.Services {
 		err := sConf.Postprocess()
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid extjwt config for service %s: %w", service, err)
 		}
 		if !sConf.Enabled() {
 			return fmt.Errorf("no keys enabled for extjwt service %s", service)
@@ -1800,6 +1802,10 @@ func LoadConfig(filename string) (config *Config, err error) {
 		return nil, err
 	}
 
+	if err = config.AuthToken.Postprocess(); err != nil {
+		return nil, err
+	}
+
 	if config.WebPush.Enabled {
 		if config.Accounts.Multiclient.AlwaysOn == PersistentDisabled {
 			return nil, fmt.Errorf("Cannot enable webpush if always-on is disabled")
@@ -1939,6 +1945,10 @@ func (config *Config) generateISupport() (err error) {
 
 	if config.Accounts.RequireSasl.Enabled {
 		isupport.Add("draft/ACCOUNTREQUIRED", "")
+	}
+
+	if config.AuthToken.Enabled {
+		isupport.Add("draft/AUTHTOKEN", "")
 	}
 
 	for key, value := range config.Server.AdditionalISupport {

--- a/irc/config.go
+++ b/irc/config.go
@@ -1805,6 +1805,9 @@ func LoadConfig(filename string) (config *Config, err error) {
 	if err = config.AuthToken.Postprocess(); err != nil {
 		return nil, err
 	}
+	if !config.AuthToken.Enabled {
+		config.Server.supportedCaps.Disable(caps.AuthToken)
+	}
 
 	if config.WebPush.Enabled {
 		if config.Accounts.Multiclient.AlwaysOn == PersistentDisabled {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3904,15 +3904,14 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "VALIDATE", client.t("TOKEN VALIDATE requires the batch capability"))
 		return
 	}
-	if len(msg.Params) < 4 {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "VALIDATE", client.t("Insufficient parameters"))
-		return
-	}
 
-	service, url, tokenChunk := msg.Params[1], msg.Params[2], msg.Params[3]
-
-	// batch case
+	// batch case, one parameter per TOKEN VALIDATE line (the token chunk)
 	if present, batchLabel := msg.GetTag("batch"); present {
+		if len(msg.Params) < 2 {
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "VALIDATE", client.t("Insufficient parameters"))
+			return
+		}
+		tokenChunk := msg.Params[1]
 		if rb.session.tokenValidateBatch != nil && rb.session.tokenValidateBatch.label == batchLabel {
 			newLen := rb.session.tokenValidateBatch.buf.Len() + len(tokenChunk)
 			if newLen <= jwt.MaxAuthTokenLength {
@@ -3926,13 +3925,18 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 		return
 	}
 
-	// single command case
+	// single command case, 3 parameters per TOKEN VALIDATE line (service, URL, token chunk)
 	if !config.AuthToken.AllowIP(client.IP()) {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
 		return
 	}
 
-	performTokenValidate(server, server.Config(), client, service, url, tokenChunk, rb)
+	if len(msg.Params) < 4 {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "VALIDATE", client.t("Insufficient parameters"))
+		return
+	}
+
+	performTokenValidate(server, server.Config(), client, msg.Params[1], msg.Params[2], msg.Params[3], rb)
 }
 
 func performTokenValidate(server *Server, config *Config, client *Client, service, url, token string, rb *ResponseBuffer) {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -620,8 +620,7 @@ func batchHandlerMultiline(server *Server, client *Client, msg ircmsg.Message, r
 
 func batchHandlerTokenStart(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
 	if rb.session.tokenValidateBatch == nil {
-		if !server.Config().AuthToken.AllowIP(client.IP()) {
-			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
+		if !tokenValidateCheckPermissions(server, server.Config(), client, rb) {
 			return false
 		}
 		if len(msg.Params) < 4 {
@@ -3899,6 +3898,21 @@ func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ir
 	}
 }
 
+// tokenValidateCheckPermissions is the check to allow a client to validate,
+// or start validating, an authtoken. we may eventually add an optional
+// PASS requirement or similar.
+func tokenValidateCheckPermissions(server *Server, config *Config, client *Client, rb *ResponseBuffer) bool {
+	if !config.AuthToken.Enabled {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Auth tokens are disabled"))
+		return false
+	}
+	if !config.AuthToken.AllowIP(client.IP()) {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
+		return false
+	}
+	return true
+}
+
 func tokenValidateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
 	if !rb.session.capabilities.Has(caps.Batch) {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "VALIDATE", client.t("TOKEN VALIDATE requires the batch capability"))
@@ -3926,8 +3940,7 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 	}
 
 	// single command case, 3 parameters per TOKEN VALIDATE line (service, URL, token chunk)
-	if !config.AuthToken.AllowIP(client.IP()) {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
+	if !tokenValidateCheckPermissions(server, config, client, rb) {
 		return
 	}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -548,11 +548,40 @@ func dispatchAwayNotify(client *Client, awayMessage string) {
 // BATCH {+,-}reference-tag type [params...]
 func batchHandler(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
 	tag := msg.Params[0]
+	if len(tag) != 0 {
+		switch tag[0] {
+		case '+':
+			// can't open a new C2S batch with one already open, even of a different type
+			if rb.session.multilineBatch.label == "" && rb.session.tokenValidateBatch == nil {
+				if len(msg.Params) >= 2 {
+					switch msg.Params[1] {
+					case caps.MultilineBatchType:
+						return batchHandlerMultiline(server, client, msg, rb)
+					case caps.AuthTokenBatchType:
+						return batchHandlerTokenStart(server, client, msg, rb)
+					}
+				}
+			}
+		case '-':
+			if rb.session.multilineBatch.label != "" {
+				return batchHandlerMultiline(server, client, msg, rb)
+			} else if rb.session.tokenValidateBatch != nil {
+				return batchHandlerTokenEnd(server, client, msg, rb)
+			}
+		}
+	}
+	failBatch(server, rb)
+	// reset any local state
+	rb.session.EndMultilineBatch("")
+	rb.session.tokenValidateBatch = nil
+	return false
+}
+
+func batchHandlerMultiline(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
+	tag := msg.Params[0]
 	fail := false
-	sendErrors := rb.session.batch.command != "NOTICE"
-	if len(tag) == 0 {
-		fail = true
-	} else if tag[0] == '+' {
+	sendErrors := rb.session.multilineBatch.command != "NOTICE"
+	if tag[0] == '+' {
 		if len(msg.Params) < 3 || msg.Params[1] != caps.MultilineBatchType {
 			fail = true
 		} else {
@@ -586,6 +615,51 @@ func batchHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respon
 		}
 	}
 
+	return false
+}
+
+func batchHandlerTokenStart(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
+	if rb.session.tokenValidateBatch == nil {
+		if !server.Config().AuthToken.AllowIP(client.IP()) {
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
+			return false
+		}
+		if len(msg.Params) < 4 {
+			failBatch(server, rb)
+			return false
+		}
+		rb.session.tokenValidateBatch = &TokenValidateBatch{
+			label:         msg.Params[0][1:],
+			responseLabel: rb.Label,
+			service:       msg.Params[2],
+			url:           msg.Params[3],
+		}
+		rb.Label = "" // suppress ACK for initial BATCH line
+	} else {
+		rb.session.tokenValidateBatch = nil
+		failBatch(server, rb)
+	}
+	return false
+}
+
+func batchHandlerTokenEnd(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
+	tokenValidateBatch := rb.session.tokenValidateBatch
+	rb.session.tokenValidateBatch = nil
+
+	if tokenValidateBatch == nil {
+		return failBatch(server, rb)
+	}
+	if tokenValidateBatch.label != msg.Params[0][1:] {
+		return failBatch(server, rb)
+	}
+
+	rb.Label = tokenValidateBatch.responseLabel
+	performTokenValidate(server, server.Config(), client, tokenValidateBatch.service, tokenValidateBatch.url, tokenValidateBatch.buf.String(), rb)
+	return false
+}
+
+func failBatch(server *Server, rb *ResponseBuffer) bool {
+	rb.Add(nil, server.name, "FAIL", "BATCH", "INVALID_PARAMS", "Corrupt BATCH")
 	return false
 }
 
@@ -2261,32 +2335,32 @@ func absorbBatchedMessage(server *Server, client *Client, msg ircmsg.Message, ba
 		}
 	}()
 
-	if batchTag != rb.session.batch.label {
+	if batchTag != rb.session.multilineBatch.label {
 		failParams = []string{"MULTILINE_INVALID", client.t("Incorrect batch tag sent")}
 		return
 	} else if len(msg.Params) < 2 {
 		failParams = []string{"MULTILINE_INVALID", client.t("Invalid multiline batch")}
 		return
 	}
-	rb.session.batch.command = msg.Command
+	rb.session.multilineBatch.command = msg.Command
 	isConcat, _ := msg.GetTag(caps.MultilineConcatTag)
 	if isConcat && len(msg.Params[1]) == 0 {
 		failParams = []string{"MULTILINE_INVALID", client.t("Cannot send a blank line with the multiline concat tag")}
 		return
 	}
-	if !isConcat && len(rb.session.batch.message.Split) != 0 {
-		rb.session.batch.lenBytes++ // bill for the newline
+	if !isConcat && len(rb.session.multilineBatch.message.Split) != 0 {
+		rb.session.multilineBatch.lenBytes++ // bill for the newline
 	}
-	rb.session.batch.message.Append(msg.Params[1], isConcat)
-	rb.session.batch.lenBytes += len(msg.Params[1])
+	rb.session.multilineBatch.message.Append(msg.Params[1], isConcat)
+	rb.session.multilineBatch.lenBytes += len(msg.Params[1])
 	config := server.Config()
-	if config.Limits.Multiline.MaxBytes < rb.session.batch.lenBytes {
+	if config.Limits.Multiline.MaxBytes < rb.session.multilineBatch.lenBytes {
 		failParams = []string{
 			"MULTILINE_MAX_BYTES",
 			strconv.Itoa(config.Limits.Multiline.MaxBytes),
 			fmt.Sprintf(client.t("Multiline batch byte limit %d exceeded"), config.Limits.Multiline.MaxBytes),
 		}
-	} else if config.Limits.Multiline.MaxLines != 0 && config.Limits.Multiline.MaxLines < rb.session.batch.message.LenLines() {
+	} else if config.Limits.Multiline.MaxLines != 0 && config.Limits.Multiline.MaxLines < rb.session.multilineBatch.message.LenLines() {
 		failParams = []string{
 			"MULTILINE_MAX_LINES",
 			strconv.Itoa(config.Limits.Multiline.MaxLines),
@@ -3765,6 +3839,10 @@ func tokenServicelistHandler(server *Server, config *Config, client *Client, msg
 }
 
 func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
+	if !rb.session.capabilities.Has(caps.Batch) {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "GENERATE", client.t("TOKEN GENERATE requires the batch capability"))
+		return
+	}
 	if len(msg.Params) < 2 {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "GENERATE", client.t("Service is a required argument to TOKEN GENERATE"))
 		return
@@ -3801,65 +3879,82 @@ func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ir
 		case jwt.ErrNoService:
 			rb.Add(nil, server.name, "FAIL", "TOKEN", "UNKNOWN_SERVICE", "GENERATE", client.t("Unknown service"))
 		default:
+			// unexpected
+			server.logger.Error("internal", "failed to issue AUTHTOKEN", err.Error())
 			rb.Add(nil, server.name, "FAIL", "TOKEN", "INTERNAL_ERROR", "GENERATE", client.t("An error occurred"))
 		}
 		return
 	}
 
-	const tokenChunkLength = 350
+	const tokenChunkLength = 400
 	srvConf := config.AuthToken.Services[service] // we already validated the service name
-	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchName, service, srvConf.URL)
+	// always send a batch; if we don't we have to try and fit service name, URL,
+	// and the entire token on the same line
+	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, service, srvConf.URL)
 	defer rb.EndNestedBatch(batchID)
 	for i := 0; i < len(token); i += tokenChunkLength {
 		end := min(len(token), i+tokenChunkLength)
 		chunk := token[i:end]
-		rb.Add(nil, server.name, "TOKEN", "GENERATE", "*", "*", chunk)
+		rb.Add(nil, "", "TOKEN", "GENERATE", "*", "*", chunk)
 	}
 }
 
 func tokenValidateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
-	var continuationExpected bool
-	defer func() {
-		if !continuationExpected {
-			rb.session.authTokenBuffer = nil
-		}
-	}()
+	if !rb.session.capabilities.Has(caps.Batch) {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "VALIDATE", client.t("TOKEN VALIDATE requires the batch capability"))
+		return
+	}
+	if len(msg.Params) < 4 {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "VALIDATE", client.t("Insufficient parameters"))
+		return
+	}
 
+	service, url, tokenChunk := msg.Params[1], msg.Params[2], msg.Params[3]
+
+	// batch case
+	if present, batchLabel := msg.GetTag("batch"); present {
+		if rb.session.tokenValidateBatch != nil && rb.session.tokenValidateBatch.label == batchLabel {
+			newLen := rb.session.tokenValidateBatch.buf.Len() + len(tokenChunk)
+			if newLen <= jwt.MaxAuthTokenLength {
+				// success, absorb into batch and wait for batch end
+				rb.session.tokenValidateBatch.buf.WriteString(tokenChunk)
+			} else {
+				rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Token exceeds maximum allowable length"))
+				rb.session.tokenValidateBatch = nil
+			}
+		}
+		return
+	}
+
+	// single command case
 	if !config.AuthToken.AllowIP(client.IP()) {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
 		return
 	}
 
-	if len(msg.Params) < 2 {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "VALIDATE", client.t("No token to validate"))
-		return
-	}
+	performTokenValidate(server, server.Config(), client, service, url, tokenChunk, rb)
+}
 
-	tokenPart := msg.Params[1]
-	if len(tokenPart) > jwt.AuthTokenPartLength || len(rb.session.authTokenBuffer)+len(tokenPart) > jwt.MaxAuthTokenLength {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Token exceeds maximum allowable length"))
-		return
-	}
-	rb.session.authTokenBuffer = append(rb.session.authTokenBuffer, tokenPart...)
-	if len(tokenPart) == 300 {
-		continuationExpected = true
-		return
-	}
-
-	claims, err := config.AuthToken.Verify(string(rb.session.authTokenBuffer))
+func performTokenValidate(server *Server, config *Config, client *Client, service, url, token string, rb *ResponseBuffer) {
+	claims, err := config.AuthToken.Verify(service, url, token)
 	if err != nil {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Invalid token"))
 		return
 	}
-	srvConf, ok := config.AuthToken.Services[claims.Service]
-	if !ok {
-		// impossible since already checked by Verify()
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Invalid token"))
+
+	subject := server.clients.Get(claims.AccountName)
+	if subject == nil || subject.AccountName() != claims.AccountName {
+		// the original issuing client is offline, or "nick equals account" is disabled
+		// in one of several possible ways (force-nick-equals-account is off, or even
+		// strict nickname reservation is off), in which case we are going to refuse
+		// to validate any claims
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Could not verify user presence"))
 		return
 	}
 
-	rb.Add(nil, server.name, "TOKEN", "CLAIM", "service", claims.Service)
-	rb.Add(nil, server.name, "TOKEN", "CLAIM", "url", srvConf.URL)
+	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, service, url)
+	defer rb.EndNestedBatch(batchID)
+
 	rb.Add(nil, server.name, "TOKEN", "CLAIM", "name", claims.AccountName)
 	rb.Add(nil, server.name, "TOKEN", "CLAIM", "account", claims.AccountName)
 	if claims.Scope != "" {
@@ -3869,11 +3964,6 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 	defer func() {
 		rb.Add(nil, server.name, "NOTE", "TOKEN", "END_OF_LIST", client.t("End of claims list"))
 	}()
-
-	subject := server.clients.Get(claims.AccountName)
-	if subject == nil || subject.AccountName() != claims.AccountName {
-		return
-	}
 
 	var memberOf, operatorOf utils.TokenLineBuilder
 	memberOf.Initialize(300, " ")

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3806,15 +3806,14 @@ func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ir
 		return
 	}
 
-	const tokenChunkLength = 300
-	for i := 0; i < len(token); i += 300 {
-		end := min(len(token), i+300)
+	const tokenChunkLength = 350
+	srvConf := config.AuthToken.Services[service] // we already validated the service name
+	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchName, service, srvConf.URL)
+	defer rb.EndNestedBatch(batchID)
+	for i := 0; i < len(token); i += tokenChunkLength {
+		end := min(len(token), i+tokenChunkLength)
 		chunk := token[i:end]
-		if end < len(token) {
-			rb.Add(nil, server.name, "TOKEN", service, "*", chunk)
-		} else {
-			rb.Add(nil, server.name, "TOKEN", service, chunk)
-		}
+		rb.Add(nil, server.name, "TOKEN", "GENERATE", "*", "*", chunk)
 	}
 }
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3853,12 +3853,12 @@ func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ir
 	}
 	details := client.Details()
 	if details.account == "" {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "ACCOUNT_REQUIRED", "GENERATE", client.t("You must be logged into an account to issue a token"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "ACCOUNT_REQUIRED", client.t("You must be logged into an account to issue a token"))
 		return
 	}
 	if details.nick != details.accountName {
 		// [evil laugh]
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "GENERATE", client.t("You must use your account name as your nickname to issue a token"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", client.t("You must use your account name as your nickname to issue a token"))
 		return
 	}
 	claims := jwt.AuthToken{
@@ -3978,10 +3978,6 @@ func performTokenValidate(server *Server, config *Config, client *Client, servic
 		rb.Add(nil, server.name, "TOKEN", "CLAIM", "scope", claims.Scope)
 	}
 
-	defer func() {
-		rb.Add(nil, server.name, "NOTE", "TOKEN", "END_OF_LIST", client.t("End of claims list"))
-	}()
-
 	var memberOf, operatorOf utils.TokenLineBuilder
 	memberOf.Initialize(300, " ")
 	operatorOf.Initialize(300, " ")
@@ -3995,7 +3991,13 @@ func performTokenValidate(server *Server, config *Config, client *Client, servic
 	}
 
 	playMultilineClaim := func(claim string, lines []string) {
-		for _, line := range lines {
+		for i, line := range lines {
+			if i != 0 {
+				// "The server produces a leading space in the second line of
+				// the member_of claim because the client must concatenate the lines
+				// together with no separators."
+				line = " " + line
+			}
 			rb.Add(nil, server.name, "TOKEN", "CLAIM", claim, line)
 		}
 	}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3812,13 +3812,13 @@ func tokenHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respon
 	switch strings.ToUpper(msg.Params[0]) {
 	case "SERVICELIST":
 		if !client.registered {
-			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "SERVICELIST", client.t("You must complete connection registration to list services"))
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "*", client.t("You must complete connection registration to list services"))
 			return false
 		}
 		tokenServicelistHandler(server, config, client, msg, rb)
 	case "GENERATE":
 		if !client.registered {
-			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "GENERATE", client.t("You must complete connection registration to issue a token"))
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "*", client.t("You must complete connection registration to issue a token"))
 			return false
 		}
 		tokenGenerateHandler(server, config, client, msg, rb)
@@ -3839,7 +3839,7 @@ func tokenServicelistHandler(server *Server, config *Config, client *Client, msg
 
 func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
 	if !rb.session.capabilities.Has(caps.Batch) {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "GENERATE", client.t("TOKEN GENERATE requires the batch capability"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "batch", client.t("TOKEN GENERATE requires the batch capability"))
 		return
 	}
 	if len(msg.Params) < 2 {
@@ -3876,11 +3876,11 @@ func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ir
 	if err != nil {
 		switch err {
 		case jwt.ErrNoService:
-			rb.Add(nil, server.name, "FAIL", "TOKEN", "UNKNOWN_SERVICE", "GENERATE", client.t("Unknown service"))
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "UNKNOWN_SERVICE", utils.SafeErrorParam(service), client.t("Unknown service"))
 		default:
 			// unexpected
 			server.logger.Error("internal", "failed to issue AUTHTOKEN", err.Error())
-			rb.Add(nil, server.name, "FAIL", "TOKEN", "INTERNAL_ERROR", "GENERATE", client.t("An error occurred"))
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "INTERNAL_ERROR", client.t("An error occurred"))
 		}
 		return
 	}
@@ -3903,11 +3903,11 @@ func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ir
 // PASS requirement or similar.
 func tokenValidateCheckPermissions(server *Server, config *Config, client *Client, rb *ResponseBuffer) bool {
 	if !config.AuthToken.Enabled {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Auth tokens are disabled"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "*", client.t("TOKEN is disabled"))
 		return false
 	}
 	if !config.AuthToken.AllowIP(client.IP()) {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "*", client.t("Your IP address is not allowed to validate auth tokens"))
 		return false
 	}
 	return true
@@ -3915,7 +3915,7 @@ func tokenValidateCheckPermissions(server *Server, config *Config, client *Clien
 
 func tokenValidateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
 	if !rb.session.capabilities.Has(caps.Batch) {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "VALIDATE", client.t("TOKEN VALIDATE requires the batch capability"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NEED_CAPABILITY", "batch", client.t("TOKEN VALIDATE requires the batch capability"))
 		return
 	}
 
@@ -3932,7 +3932,7 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 				// success, absorb into batch and wait for batch end
 				rb.session.tokenValidateBatch.buf.WriteString(tokenChunk)
 			} else {
-				rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Token exceeds maximum allowable length"))
+				rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", client.t("Token exceeds maximum allowable length"))
 				rb.session.tokenValidateBatch = nil
 			}
 		}
@@ -3955,7 +3955,7 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 func performTokenValidate(server *Server, config *Config, client *Client, service, url, token string, rb *ResponseBuffer) {
 	claims, err := config.AuthToken.Verify(service, url, token)
 	if err != nil {
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Invalid token"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", client.t("Invalid token"))
 		return
 	}
 
@@ -3965,7 +3965,7 @@ func performTokenValidate(server *Server, config *Config, client *Client, servic
 		// in one of several possible ways (force-nick-equals-account is off, or even
 		// strict nickname reservation is off), in which case we are going to refuse
 		// to validate any claims
-		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Could not verify user presence"))
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", client.t("Could not verify user presence"))
 		return
 	}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3978,12 +3978,8 @@ func performTokenValidate(server *Server, config *Config, client *Client, servic
 	}
 
 	playMultilineClaim := func(claim string, lines []string) {
-		for i, line := range lines {
-			if i < len(lines)-1 {
-				rb.Add(nil, server.name, "TOKEN", "CLAIM", claim, "*", line)
-			} else {
-				rb.Add(nil, server.name, "TOKEN", "CLAIM", claim, line)
-			}
+		for _, line := range lines {
+			rb.Add(nil, server.name, "TOKEN", "CLAIM", claim, line)
 		}
 	}
 	playMultilineClaim("member_of", memberOf.Lines())

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1190,7 +1190,7 @@ func extjwtHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 		return false
 	}
 
-	tokenString, err := sConfig.Sign(claims)
+	tokenString, err := sConfig.SignEXTJWT(claims)
 
 	if err == nil {
 		maxTokenLength := maxLastArgLength
@@ -3726,6 +3726,181 @@ func summonHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respo
 func timeHandler(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
 	rb.Add(nil, server.name, RPL_TIME, client.nick, server.name, time.Now().UTC().Format(time.RFC1123))
 	return false
+}
+
+// TOKEN
+func tokenHandler(server *Server, client *Client, msg ircmsg.Message, rb *ResponseBuffer) bool {
+	config := server.Config()
+	if !config.AuthToken.Enabled {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "*", client.t("TOKEN is disabled"))
+		return false
+	}
+
+	switch strings.ToUpper(msg.Params[0]) {
+	case "SERVICELIST":
+		if !client.registered {
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "SERVICELIST", client.t("You must complete connection registration to list services"))
+			return false
+		}
+		tokenServicelistHandler(server, config, client, msg, rb)
+	case "GENERATE":
+		if !client.registered {
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "GENERATE", client.t("You must complete connection registration to issue a token"))
+			return false
+		}
+		tokenGenerateHandler(server, config, client, msg, rb)
+	case "VALIDATE":
+		tokenValidateHandler(server, config, client, msg, rb)
+	default:
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "UNKNOWN_COMMAND", utils.SafeErrorParam(msg.Params[0]), client.t("Unknown subcommand"))
+	}
+	return false
+}
+
+func tokenServicelistHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
+	for srv, conf := range config.AuthToken.Services {
+		rb.Add(nil, server.name, "NOTE", "TOKEN", "SERVICE", srv, conf.URL, conf.Description)
+	}
+	rb.Add(nil, server.name, "NOTE", "TOKEN", "END_OF_LIST", client.t("End of service list"))
+}
+
+func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
+	if len(msg.Params) < 2 {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "GENERATE", client.t("Service is a required argument to TOKEN GENERATE"))
+		return
+	}
+	service := strings.ToUpper(msg.Params[1])
+	var scope string
+	if len(msg.Params) > 2 {
+		scope = msg.Params[2]
+	}
+	details := client.Details()
+	if details.account == "" {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "ACCOUNT_REQUIRED", "GENERATE", client.t("You must be logged into an account to issue a token"))
+		return
+	}
+	if details.nick != details.accountName {
+		// [evil laugh]
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "GENERATE", client.t("You must use your account name as your nickname to issue a token"))
+		return
+	}
+	claims := jwt.AuthToken{
+		ServerName:  server.name,
+		Service:     service,
+		Scope:       scope,
+		AccountName: details.accountName,
+	}
+	if channel := server.channels.Get(scope); channel != nil {
+		if m := channel.HighestUserMode(client); m != 0 {
+			claims.ChannelMode = string(m)
+		}
+	}
+	token, err := config.AuthToken.Issue(claims)
+	if err != nil {
+		switch err {
+		case jwt.ErrNoService:
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "UNKNOWN_SERVICE", "GENERATE", client.t("Unknown service"))
+		default:
+			rb.Add(nil, server.name, "FAIL", "TOKEN", "INTERNAL_ERROR", "GENERATE", client.t("An error occurred"))
+		}
+		return
+	}
+
+	const tokenChunkLength = 300
+	for i := 0; i < len(token); i += 300 {
+		end := min(len(token), i+300)
+		chunk := token[i:end]
+		if end < len(token) {
+			rb.Add(nil, server.name, "TOKEN", service, "*", chunk)
+		} else {
+			rb.Add(nil, server.name, "TOKEN", service, chunk)
+		}
+	}
+}
+
+func tokenValidateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
+	var continuationExpected bool
+	defer func() {
+		if !continuationExpected {
+			rb.session.authTokenBuffer = nil
+		}
+	}()
+
+	if !config.AuthToken.AllowIP(client.IP()) {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "VALIDATE", client.t("Your IP address is not allowed to validate auth tokens"))
+		return
+	}
+
+	if len(msg.Params) < 2 {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "VALIDATE", client.t("No token to validate"))
+		return
+	}
+
+	tokenPart := msg.Params[1]
+	if len(tokenPart) > jwt.AuthTokenPartLength || len(rb.session.authTokenBuffer)+len(tokenPart) > jwt.MaxAuthTokenLength {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Token exceeds maximum allowable length"))
+		return
+	}
+	rb.session.authTokenBuffer = append(rb.session.authTokenBuffer, tokenPart...)
+	if len(tokenPart) == 300 {
+		continuationExpected = true
+		return
+	}
+
+	claims, err := config.AuthToken.Verify(string(rb.session.authTokenBuffer))
+	if err != nil {
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Invalid token"))
+		return
+	}
+	srvConf, ok := config.AuthToken.Services[claims.Service]
+	if !ok {
+		// impossible since already checked by Verify()
+		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", "VALIDATE", client.t("Invalid token"))
+		return
+	}
+
+	rb.Add(nil, server.name, "TOKEN", "CLAIM", "service", claims.Service)
+	rb.Add(nil, server.name, "TOKEN", "CLAIM", "url", srvConf.URL)
+	rb.Add(nil, server.name, "TOKEN", "CLAIM", "name", claims.AccountName)
+	rb.Add(nil, server.name, "TOKEN", "CLAIM", "account", claims.AccountName)
+	if claims.Scope != "" {
+		rb.Add(nil, server.name, "TOKEN", "CLAIM", "scope", claims.Scope)
+	}
+
+	defer func() {
+		rb.Add(nil, server.name, "NOTE", "TOKEN", "END_OF_LIST", client.t("End of claims list"))
+	}()
+
+	subject := server.clients.Get(claims.AccountName)
+	if subject == nil || subject.AccountName() != claims.AccountName {
+		return
+	}
+
+	var memberOf, operatorOf utils.TokenLineBuilder
+	memberOf.Initialize(300, " ")
+	operatorOf.Initialize(300, " ")
+
+	for _, channel := range subject.Channels() {
+		chname := channel.Name()
+		memberOf.Add(chname)
+		if channel.ClientIsAtLeast(subject, modes.ChannelOperator) {
+			operatorOf.Add(chname)
+		}
+	}
+
+	playMultilineClaim := func(claim string, lines []string) {
+		for i, line := range lines {
+			if i < len(lines)-1 {
+				rb.Add(nil, server.name, "TOKEN", "CLAIM", claim, "*", line)
+			} else {
+				rb.Add(nil, server.name, "TOKEN", "CLAIM", claim, line)
+			}
+		}
+	}
+	playMultilineClaim("member_of", memberOf.Lines())
+	playMultilineClaim("operator_of", operatorOf.Lines())
+
+	return
 }
 
 // TOPIC <channel> [<topic>]

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -623,7 +623,7 @@ func batchHandlerTokenStart(server *Server, client *Client, msg ircmsg.Message, 
 		if !tokenValidateCheckPermissions(server, server.Config(), client, rb) {
 			return false
 		}
-		if len(msg.Params) < 4 {
+		if len(msg.Params) < 3 {
 			failBatch(server, rb)
 			return false
 		}
@@ -3891,15 +3891,14 @@ func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ir
 	}
 
 	const tokenChunkLength = 400
-	srvConf := config.AuthToken.Services[service] // we already validated the service name
-	// always send a batch; if we don't we have to try and fit service name, URL,
+	// always send a batch; if we don't we have to try and fit service name
 	// and the entire token on the same line
-	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, service, srvConf.URL)
+	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, service)
 	defer rb.EndNestedBatch(batchID)
 	for i := 0; i < len(token); i += tokenChunkLength {
 		end := min(len(token), i+tokenChunkLength)
 		chunk := token[i:end]
-		rb.Add(nil, "", "TOKEN", "GENERATE", "*", "*", chunk)
+		rb.Add(nil, "", "TOKEN", "GENERATE", "*", chunk)
 	}
 }
 
@@ -3949,7 +3948,7 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 		return
 	}
 
-	if len(msg.Params) < 4 {
+	if len(msg.Params) < 3 {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_PARAMS", "VALIDATE", client.t("Insufficient parameters"))
 		return
 	}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3815,7 +3815,7 @@ func tokenHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respon
 			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "*", client.t("You must complete connection registration to list services"))
 			return false
 		}
-		tokenServicelistHandler(server, config, client, msg, rb)
+		tokenServicelistHandler(server, config, client, rb)
 	case "GENERATE":
 		if !client.registered {
 			rb.Add(nil, server.name, "FAIL", "TOKEN", "NO_PERMISSIONS", "*", client.t("You must complete connection registration to issue a token"))
@@ -3830,11 +3830,16 @@ func tokenHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respon
 	return false
 }
 
-func tokenServicelistHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {
-	for srv, conf := range config.AuthToken.Services {
-		rb.Add(nil, server.name, "NOTE", "TOKEN", "SERVICE", srv, conf.URL, conf.Description)
+func tokenServicelistHandler(server *Server, config *Config, client *Client, rb *ResponseBuffer) {
+	if len(config.AuthToken.Services) == 0 {
+		rb.Add(nil, server.name, "NOTE", "TOKEN", "NO_SERVICES", client.t("No services are defined for this network"))
+		return
 	}
-	rb.Add(nil, server.name, "NOTE", "TOKEN", "END_OF_LIST", client.t("End of service list"))
+	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, "*", "*")
+	defer rb.EndNestedBatch(batchID)
+	for srv, conf := range config.AuthToken.Services {
+		rb.Add(nil, server.name, "TOKEN", "SERVICE", srv, conf.URL, conf.Description)
+	}
 }
 
 func tokenGenerateHandler(server *Server, config *Config, client *Client, msg ircmsg.Message, rb *ResponseBuffer) {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3957,6 +3957,7 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 }
 
 func performTokenValidate(server *Server, config *Config, client *Client, service, token string, rb *ResponseBuffer) {
+	service = strings.ToUpper(service)
 	claims, err := config.AuthToken.Verify(service, token)
 	if err != nil {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", client.t("Invalid token"))

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -631,7 +631,6 @@ func batchHandlerTokenStart(server *Server, client *Client, msg ircmsg.Message, 
 			label:         msg.Params[0][1:],
 			responseLabel: rb.Label,
 			service:       msg.Params[2],
-			url:           msg.Params[3],
 		}
 		rb.Label = "" // suppress ACK for initial BATCH line
 	} else {
@@ -653,7 +652,7 @@ func batchHandlerTokenEnd(server *Server, client *Client, msg ircmsg.Message, rb
 	}
 
 	rb.Label = tokenValidateBatch.responseLabel
-	performTokenValidate(server, server.Config(), client, tokenValidateBatch.service, tokenValidateBatch.url, tokenValidateBatch.buf.String(), rb)
+	performTokenValidate(server, server.Config(), client, tokenValidateBatch.service, tokenValidateBatch.buf.String(), rb)
 	return false
 }
 
@@ -3955,11 +3954,11 @@ func tokenValidateHandler(server *Server, config *Config, client *Client, msg ir
 		return
 	}
 
-	performTokenValidate(server, server.Config(), client, msg.Params[1], msg.Params[2], msg.Params[3], rb)
+	performTokenValidate(server, server.Config(), client, msg.Params[1], msg.Params[2], rb)
 }
 
-func performTokenValidate(server *Server, config *Config, client *Client, service, url, token string, rb *ResponseBuffer) {
-	claims, err := config.AuthToken.Verify(service, url, token)
+func performTokenValidate(server *Server, config *Config, client *Client, service, token string, rb *ResponseBuffer) {
+	claims, err := config.AuthToken.Verify(service, token)
 	if err != nil {
 		rb.Add(nil, server.name, "FAIL", "TOKEN", "INVALID_TOKEN", client.t("Invalid token"))
 		return
@@ -3975,7 +3974,7 @@ func performTokenValidate(server *Server, config *Config, client *Client, servic
 		return
 	}
 
-	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, service, url)
+	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, service)
 	defer rb.EndNestedBatch(batchID)
 
 	rb.Add(nil, server.name, "TOKEN", "CLAIM", "name", claims.AccountName)

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -3835,7 +3835,7 @@ func tokenServicelistHandler(server *Server, config *Config, client *Client, rb 
 		rb.Add(nil, server.name, "NOTE", "TOKEN", "NO_SERVICES", client.t("No services are defined for this network"))
 		return
 	}
-	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, "*", "*")
+	batchID := rb.StartNestedBatch(nil, caps.AuthTokenBatchType, "*")
 	defer rb.EndNestedBatch(batchID)
 	for srv, conf := range config.AuthToken.Services {
 		rb.Add(nil, server.name, "TOKEN", "SERVICE", srv, conf.URL, conf.Description)

--- a/irc/help.go
+++ b/irc/help.go
@@ -533,6 +533,12 @@ Reloads the config file and updates TLS certificates on listeners`,
 
 Shows the time of the current, or the given, server.`,
 	},
+	"token": {
+		text: `TOKEN <subcommand> [args]
+
+TOKEN issues and validates tokens for use by external services.
+It is not intended for direct use by end users.`,
+	},
 	"topic": {
 		text: `TOPIC <channel> [topic]
 

--- a/irc/jwt/authtoken.go
+++ b/irc/jwt/authtoken.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ergochat/ergo/irc/utils"
+
 	jwt "github.com/golang-jwt/jwt/v5"
 )
 
@@ -36,6 +37,7 @@ type AuthTokensConfig struct {
 type AuthToken struct {
 	ServerName  string
 	Service     string
+	URL         string
 	AccountName string
 	Scope       string
 	ChannelMode string
@@ -98,11 +100,10 @@ func (t *AuthTokensConfig) Issue(token AuthToken) (result string, err error) {
 	// standard claims:
 	claims["iss"] = token.ServerName
 	claims["exp"] = time.Now().Unix() + int64(conf.Expiration/time.Second)
-	// aud is probably a waste of bits for our use case, but the spec says we should publish it
 	claims["aud"] = conf.URL
 	// ergo-specific claims
 	claims["srv"] = service
-	claims["account"] = token.AccountName
+	claims["acc"] = token.AccountName
 	if token.Scope != "" {
 		claims["scope"] = token.Scope
 	}
@@ -115,24 +116,14 @@ func (t *AuthTokensConfig) Issue(token AuthToken) (result string, err error) {
 	return j.SignedString(conf.signingKey)
 }
 
-func (t *AuthTokensConfig) Verify(token string) (result AuthToken, err error) {
-	var conf JwtServiceConfig
-
-	// parse the token; extract the unvalidated srv claim; retrieve the corresponding
-	// JWT service definition and verify the signature against the defined key
-	tok, err := parser.Parse(token, func(tok *jwt.Token) (key any, err error) {
-		srvClaim := tok.Claims.(jwt.MapClaims)["srv"] // Parse always returns a MapClaims
-		if serviceName, ok := srvClaim.(string); ok {
-			conf, err = t.getService(serviceName)
-			if err == nil {
-				return conf.verifyKey, nil
-			} else {
-				return nil, err
-			}
-		} else {
-			return nil, ErrInvalidToken
-		}
-	})
+func (t *AuthTokensConfig) Verify(service, url, token string) (result AuthToken, err error) {
+	service = strings.ToUpper(service)
+	conf, err := t.getService(service)
+	if err != nil {
+		return
+	}
+	// since we looked up the service, we now know the correct signing key
+	tok, err := parser.Parse(token, conf.verifyKeyFunc)
 	if err != nil {
 		return
 	}
@@ -145,19 +136,33 @@ func (t *AuthTokensConfig) Verify(token string) (result AuthToken, err error) {
 	}
 
 	mc := tok.Claims.(jwt.MapClaims)
-	extractStringClaim := func(claims jwt.MapClaims, key string) string {
-		if result, ok := claims[key]; ok {
-			if strResult, ok := result.(string); ok {
-				return strResult
-			}
-		}
-		return ""
+
+	srvClaim := extractStringClaim(mc, "srv")
+	if service != srvClaim {
+		err = ErrInvalidToken
+		return
 	}
+	audClaim := extractStringClaim(mc, "aud")
+	if url != audClaim {
+		err = ErrInvalidToken
+		return
+	}
+
 	return AuthToken{
-		// don't care about ServerName
-		Service:     extractStringClaim(mc, "srv"),
-		AccountName: extractStringClaim(mc, "account"),
+		// don't care about iss / ServerName
+		Service:     srvClaim,
+		URL:         audClaim,
+		AccountName: extractStringClaim(mc, "acc"),
 		Scope:       extractStringClaim(mc, "scope"),
 		// don't return channel mode, revalidate it from runtime data
 	}, nil
+}
+
+func extractStringClaim(claims jwt.MapClaims, key string) string {
+	if result, ok := claims[key]; ok {
+		if strResult, ok := result.(string); ok {
+			return strResult
+		}
+	}
+	return ""
 }

--- a/irc/jwt/authtoken.go
+++ b/irc/jwt/authtoken.go
@@ -1,0 +1,163 @@
+package jwt
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/ergochat/ergo/irc/utils"
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	AuthTokenPartLength = 300
+	MaxAuthTokenLength  = 2048 // TODO check this
+)
+
+var (
+	ErrInvalidToken = errors.New("invalid token")
+	ErrNoService    = errors.New("invalid authtoken service")
+
+	parser = jwt.NewParser(jwt.WithExpirationRequired())
+)
+
+type AuthTokensConfig struct {
+	Enabled                 bool
+	VerificationIPWhitelist []string `yaml:"verification-ip-whitelist"`
+	verificationIPWhitelist []net.IPNet
+
+	Services map[string]JwtServiceConfig
+}
+
+// AuthToken is the internal representation of an auth token's data,
+// implemented as a stateless signed JWT.
+type AuthToken struct {
+	ServerName  string
+	Service     string
+	AccountName string
+	Scope       string
+	ChannelMode string
+}
+
+func (t *AuthTokensConfig) Postprocess() (err error) {
+	if !t.Enabled {
+		return nil
+	}
+
+	t.verificationIPWhitelist, err = utils.ParseNetList(t.VerificationIPWhitelist)
+	if err != nil {
+		return err
+	}
+
+	services := make(map[string]JwtServiceConfig, len(t.Services))
+	for srv, conf := range t.Services {
+		if err := conf.Postprocess(); err != nil {
+			return fmt.Errorf("TOKEN service %s is misconfigured: %w", srv, err)
+		}
+		if !conf.Enabled() {
+			return fmt.Errorf("TOKEN service %s lacks necessary configuration", srv)
+		}
+		if conf.URL == "" {
+			return fmt.Errorf("TOKEN service %s lacks a URL", srv)
+		}
+		services[strings.ToUpper(srv)] = conf
+	}
+	t.Services = services
+	return nil
+}
+
+func (t *AuthTokensConfig) getService(service string) (result JwtServiceConfig, err error) {
+	if !t.Enabled {
+		err = ErrNoService
+		return
+	}
+
+	result, ok := t.Services[service]
+	if !ok || !result.Enabled() {
+		err = ErrNoService
+		return
+	}
+
+	return result, nil
+}
+
+func (t *AuthTokensConfig) AllowIP(ip net.IP) bool {
+	return utils.IPInNets(ip, t.verificationIPWhitelist)
+}
+
+func (t *AuthTokensConfig) Issue(token AuthToken) (result string, err error) {
+	service := strings.ToUpper(token.Service)
+	conf, err := t.getService(service)
+	if err != nil {
+		return
+	}
+
+	claims := make(jwt.MapClaims)
+	// standard claims:
+	claims["iss"] = token.ServerName
+	claims["exp"] = time.Now().Unix() + int64(conf.Expiration/time.Second)
+	// aud is probably a waste of bits for our use case, but the spec says we should publish it
+	claims["aud"] = conf.URL
+	// ergo-specific claims
+	claims["srv"] = service
+	claims["account"] = token.AccountName
+	if token.Scope != "" {
+		claims["scope"] = token.Scope
+	}
+	if token.ChannelMode != "" {
+		claims["chmode"] = token.ChannelMode
+	}
+	// TODO include operclass if available?
+
+	j := jwt.NewWithClaims(conf.signingMethod, jwt.MapClaims(claims))
+	return j.SignedString(conf.signingKey)
+}
+
+func (t *AuthTokensConfig) Verify(token string) (result AuthToken, err error) {
+	var conf JwtServiceConfig
+
+	// parse the token; extract the unvalidated srv claim; retrieve the corresponding
+	// JWT service definition and verify the signature against the defined key
+	tok, err := parser.Parse(token, func(tok *jwt.Token) (key any, err error) {
+		srvClaim := tok.Claims.(jwt.MapClaims)["srv"] // Parse always returns a MapClaims
+		if serviceName, ok := srvClaim.(string); ok {
+			conf, err = t.getService(serviceName)
+			if err == nil {
+				return conf.verifyKey, nil
+			} else {
+				return nil, err
+			}
+		} else {
+			return nil, ErrInvalidToken
+		}
+	})
+	if err != nil {
+		return
+	}
+
+	// validate the exact signing method just in case (although it should be impossible
+	// to, e.g. validate a HS256 token with a *rsa.PrivateKey signing key)
+	if tok.Method != conf.signingMethod {
+		err = ErrInvalidToken
+		return
+	}
+
+	mc := tok.Claims.(jwt.MapClaims)
+	extractStringClaim := func(claims jwt.MapClaims, key string) string {
+		if result, ok := claims[key]; ok {
+			if strResult, ok := result.(string); ok {
+				return strResult
+			}
+		}
+		return ""
+	}
+	return AuthToken{
+		// don't care about ServerName
+		Service:     extractStringClaim(mc, "srv"),
+		AccountName: extractStringClaim(mc, "account"),
+		Scope:       extractStringClaim(mc, "scope"),
+		// don't return channel mode, revalidate it from runtime data
+	}, nil
+}

--- a/irc/jwt/authtoken.go
+++ b/irc/jwt/authtoken.go
@@ -44,6 +44,7 @@ type AuthToken struct {
 
 func (t *AuthTokensConfig) Postprocess() (err error) {
 	if !t.Enabled {
+		t.Services = nil // simplify diffing later
 		return nil
 	}
 
@@ -67,6 +68,22 @@ func (t *AuthTokensConfig) Postprocess() (err error) {
 	}
 	t.Services = services
 	return nil
+}
+
+func (oldConf *AuthTokensConfig) GetDifference(newConf AuthTokensConfig) (result [][]string) {
+	for srv := range oldConf.Services {
+		if _, ok := newConf.Services[srv]; !ok {
+			result = append(result, []string{"DEL", srv})
+		}
+	}
+
+	for srv, conf := range newConf.Services {
+		if oldConf, ok := oldConf.Services[srv]; !ok || conf.URL != oldConf.URL {
+			result = append(result, []string{"NEW", srv, conf.URL})
+		}
+	}
+
+	return
 }
 
 func (t *AuthTokensConfig) getService(service string) (result JwtServiceConfig, err error) {

--- a/irc/jwt/authtoken.go
+++ b/irc/jwt/authtoken.go
@@ -116,7 +116,7 @@ func (t *AuthTokensConfig) Issue(token AuthToken) (result string, err error) {
 	return j.SignedString(conf.signingKey)
 }
 
-func (t *AuthTokensConfig) Verify(service, url, token string) (result AuthToken, err error) {
+func (t *AuthTokensConfig) Verify(service, token string) (result AuthToken, err error) {
 	service = strings.ToUpper(service)
 	conf, err := t.getService(service)
 	if err != nil {
@@ -143,7 +143,7 @@ func (t *AuthTokensConfig) Verify(service, url, token string) (result AuthToken,
 		return
 	}
 	audClaim := extractStringClaim(mc, "aud")
-	if url != audClaim {
+	if conf.URL != audClaim {
 		err = ErrInvalidToken
 		return
 	}

--- a/irc/jwt/authtoken.go
+++ b/irc/jwt/authtoken.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	AuthTokenPartLength = 300
-	MaxAuthTokenLength  = 2048 // TODO check this
+	MaxAuthTokenLength = 2048 // TODO check this
 )
 
 var (

--- a/irc/jwt/authtoken_test.go
+++ b/irc/jwt/authtoken_test.go
@@ -1,0 +1,52 @@
+package jwt
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAuthTokenRoundTrip(t *testing.T) {
+	conf := AuthTokensConfig{
+		Enabled: true,
+		Services: map[string]JwtServiceConfig{
+			"FILEHOST": {
+				Expiration: 10 * time.Minute,
+				URL:        "https://example.com",
+				Algorithm:  "rsa",
+				KeyString:  rsaTestPrivKey,
+			},
+		},
+	}
+
+	err := conf.Postprocess()
+	if err != nil {
+		t.Fatalf("couldn't parse config: %v", err)
+	}
+
+	tok := AuthToken{
+		ServerName:  "irc.ergo.chat",
+		Service:     "FILEHOST",
+		AccountName: "slingamn",
+		Scope:       "#ergo",
+		ChannelMode: "o",
+	}
+
+	jtok, err := conf.Issue(tok)
+	if err != nil {
+		t.Fatalf("couldn't issue token: %v", err)
+	}
+
+	result, err := conf.Verify("FILEHOST", "https://example.com", jtok)
+	if err != nil {
+		t.Errorf("couldn't validate token: %v", err)
+	}
+
+	if result.AccountName != "slingamn" || result.Scope != "#ergo" {
+		t.Errorf("didn't recover required fields from token: %#v", result)
+	}
+
+	_, err = conf.Verify("FILEHOST", "https://example.com", jtok[:len(jtok)-1])
+	if err == nil {
+		t.Errorf("validated token with bad signature")
+	}
+}

--- a/irc/jwt/authtoken_test.go
+++ b/irc/jwt/authtoken_test.go
@@ -36,7 +36,7 @@ func TestAuthTokenRoundTrip(t *testing.T) {
 		t.Fatalf("couldn't issue token: %v", err)
 	}
 
-	result, err := conf.Verify("FILEHOST", "https://example.com", jtok)
+	result, err := conf.Verify("FILEHOST", jtok)
 	if err != nil {
 		t.Errorf("couldn't validate token: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestAuthTokenRoundTrip(t *testing.T) {
 		t.Errorf("didn't recover required fields from token: %#v", result)
 	}
 
-	_, err = conf.Verify("FILEHOST", "https://example.com", jtok[:len(jtok)-1])
+	_, err = conf.Verify("FILEHOST", jtok[:len(jtok)-1])
 	if err == nil {
 		t.Errorf("validated token with bad signature")
 	}

--- a/irc/jwt/authtoken_test.go
+++ b/irc/jwt/authtoken_test.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -48,5 +49,71 @@ func TestAuthTokenRoundTrip(t *testing.T) {
 	_, err = conf.Verify("FILEHOST", jtok[:len(jtok)-1])
 	if err == nil {
 		t.Errorf("validated token with bad signature")
+	}
+}
+
+func TestAuthTokenDiff(t *testing.T) {
+	oldConf := AuthTokensConfig{
+		Enabled: true,
+		Services: map[string]JwtServiceConfig{
+			"FILEHOST": {
+				Expiration: 10 * time.Minute,
+				URL:        "https://example.com/filehost",
+				Algorithm:  "rsa",
+				KeyString:  rsaTestPrivKey,
+			},
+			"QDB": {
+				Expiration: 10 * time.Minute,
+				URL:        "https://example.com/qdb",
+				Algorithm:  "hmac",
+				KeyString:  "MbKjh6CTqLMPZV9XLYmACw",
+			},
+			"JITSI": {
+				Expiration: 10 * time.Minute,
+				URL:        "https://example.com/jitsi",
+				Algorithm:  "hmac",
+				KeyString:  "uaKzJTbuqjHlbGrvwku2kw",
+			},
+		},
+	}
+
+	err := oldConf.Postprocess()
+	if err != nil {
+		t.Fatalf("couldn't parse config: %v", err)
+	}
+
+	newConf := AuthTokensConfig{
+		Enabled: true,
+		Services: map[string]JwtServiceConfig{
+			// change the filehost URL
+			"FILEHOST": {
+				Expiration: 10 * time.Minute,
+				URL:        "https://filehost.com/filehost",
+				Algorithm:  "rsa",
+				KeyString:  rsaTestPrivKey,
+			},
+			// QDB is deleted
+			// jitsi is at the same URL with a different key
+			"JITSI": {
+				Expiration: 10 * time.Minute,
+				URL:        "https://example.com/jitsi",
+				Algorithm:  "rsa",
+				KeyString:  rsaTestPrivKey,
+			},
+		},
+	}
+
+	err = newConf.Postprocess()
+	if err != nil {
+		t.Fatalf("couldn't parse config: %v", err)
+	}
+
+	expectedDiff := [][]string{
+		{"DEL", "QDB"},
+		{"NEW", "FILEHOST", "https://filehost.com/filehost"},
+	}
+	diff := oldConf.GetDifference(newConf)
+	if !reflect.DeepEqual(diff, expectedDiff) {
+		t.Fatalf("incorrect diff: %#v", diff)
 	}
 }

--- a/irc/jwt/bearer.go
+++ b/irc/jwt/bearer.go
@@ -81,7 +81,7 @@ func (j *JWTAuthTokenConfig) Postprocess() error {
 	default:
 		return fmt.Errorf("invalid jwt algorithm: %s", j.Algorithm)
 	}
-	j.parser = jwt.NewParser(jwt.WithValidMethods(methods))
+	j.parser = jwt.NewParser(jwt.WithValidMethods(methods), jwt.WithExpirationRequired())
 
 	if len(j.AccountClaims) == 0 {
 		return fmt.Errorf("JWT auth enabled, but no account-claims specified")

--- a/irc/jwt/bearer.go
+++ b/irc/jwt/bearer.go
@@ -177,6 +177,15 @@ func (j *JWTAuthTokenConfig) validateAudClaim(claims jwt.MapClaims) bool {
 	switch aud := audClaim.(type) {
 	case string:
 		return j.allowedAuds.Has(aud)
+	case []any:
+		for _, a := range aud {
+			if aStr, ok := a.(string); ok {
+				if j.allowedAuds.Has(aStr) {
+					return true
+				}
+			}
+		}
+		return false
 	case []string:
 		for _, a := range aud {
 			if j.allowedAuds.Has(a) {

--- a/irc/jwt/bearer.go
+++ b/irc/jwt/bearer.go
@@ -20,12 +20,12 @@ var (
 
 // JWTAuthConfig is the config for Ergo to accept JWTs via draft/bearer
 type JWTAuthConfig struct {
-	Enabled    bool                 `yaml:"enabled"`
-	Autocreate bool                 `yaml:"autocreate"`
-	Tokens     []JWTAuthTokenConfig `yaml:"tokens"`
+	Enabled    bool                   `yaml:"enabled"`
+	Autocreate bool                   `yaml:"autocreate"`
+	Tokens     []JWTBearerTokenConfig `yaml:"tokens"`
 }
 
-type JWTAuthTokenConfig struct {
+type JWTBearerTokenConfig struct {
 	Algorithm     string `yaml:"algorithm"`
 	KeyString     string `yaml:"key"`
 	KeyFile       string `yaml:"key-file"`
@@ -55,7 +55,7 @@ func (j *JWTAuthConfig) Postprocess() error {
 	return nil
 }
 
-func (j *JWTAuthTokenConfig) Postprocess() error {
+func (j *JWTBearerTokenConfig) Postprocess() error {
 	keyBytes, err := j.keyBytes()
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (j *JWTAuthConfig) Validate(t string) (accountName string, err error) {
 	return
 }
 
-func (j *JWTAuthTokenConfig) keyBytes() (result []byte, err error) {
+func (j *JWTBearerTokenConfig) keyBytes() (result []byte, err error) {
 	if j.KeyFile != "" {
 		return os.ReadFile(j.KeyFile)
 	}
@@ -125,11 +125,11 @@ func (j *JWTAuthTokenConfig) keyBytes() (result []byte, err error) {
 }
 
 // implements jwt.Keyfunc
-func (j *JWTAuthTokenConfig) keyFunc(_ *jwt.Token) (interface{}, error) {
+func (j *JWTBearerTokenConfig) keyFunc(_ *jwt.Token) (interface{}, error) {
 	return j.key, nil
 }
 
-func (j *JWTAuthTokenConfig) Validate(t string) (accountName string, err error) {
+func (j *JWTBearerTokenConfig) Validate(t string) (accountName string, err error) {
 	token, err := j.parser.Parse(t, j.keyFunc)
 	if err != nil {
 		return "", err
@@ -164,7 +164,7 @@ func (j *JWTAuthTokenConfig) Validate(t string) (accountName string, err error) 
 	return "", ErrNoValidAccountClaim
 }
 
-func (j *JWTAuthTokenConfig) validateAudClaim(claims jwt.MapClaims) bool {
+func (j *JWTBearerTokenConfig) validateAudClaim(claims jwt.MapClaims) bool {
 	if j.allowedAuds == nil {
 		return true // no validate-aud means any aud is allowed
 	}

--- a/irc/jwt/bearer.go
+++ b/irc/jwt/bearer.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ergochat/ergo/irc/utils"
 	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 var (
 	ErrAuthDisabled        = fmt.Errorf("JWT authentication is disabled")
 	ErrNoValidAccountClaim = fmt.Errorf("JWT token did not contain an acceptable account name claim")
+	ErrNoValidAudClaim     = fmt.Errorf("JWT token did not contain an acceptable aud claim")
 )
 
 // JWTAuthConfig is the config for Ergo to accept JWTs via draft/bearer
@@ -31,6 +33,8 @@ type JWTAuthTokenConfig struct {
 	parser        *jwt.Parser
 	AccountClaims []string `yaml:"account-claims"`
 	StripDomain   string   `yaml:"strip-domain"`
+	ValidateAud   []string `yaml:"validate-aud"`
+	allowedAuds   utils.HashSet[string]
 }
 
 func (j *JWTAuthConfig) Postprocess() error {
@@ -88,6 +92,11 @@ func (j *JWTAuthTokenConfig) Postprocess() error {
 	}
 
 	j.StripDomain = strings.ToLower(j.StripDomain)
+
+	if len(j.ValidateAud) != 0 {
+		j.allowedAuds = utils.SetLiteral(j.ValidateAud...)
+	}
+
 	return nil
 }
 
@@ -132,6 +141,10 @@ func (j *JWTAuthTokenConfig) Validate(t string) (accountName string, err error) 
 		return "", fmt.Errorf("unexpected type from parsed token claims: %T", claims)
 	}
 
+	if !j.validateAudClaim(claims) {
+		return "", ErrNoValidAudClaim
+	}
+
 	for _, c := range j.AccountClaims {
 		if v, ok := claims[c]; ok {
 			if vstr, ok := v.(string); ok {
@@ -149,4 +162,29 @@ func (j *JWTAuthTokenConfig) Validate(t string) (accountName string, err error) 
 	}
 
 	return "", ErrNoValidAccountClaim
+}
+
+func (j *JWTAuthTokenConfig) validateAudClaim(claims jwt.MapClaims) bool {
+	if j.allowedAuds == nil {
+		return true // no validate-aud means any aud is allowed
+	}
+
+	audClaim, ok := claims["aud"]
+	if !ok {
+		return false
+	}
+
+	switch aud := audClaim.(type) {
+	case string:
+		return j.allowedAuds.Has(aud)
+	case []string:
+		for _, a := range aud {
+			if j.allowedAuds.Has(a) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }

--- a/irc/jwt/bearer.go
+++ b/irc/jwt/bearer.go
@@ -5,7 +5,6 @@ package jwt
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -108,12 +107,7 @@ func (j *JWTAuthConfig) Validate(t string) (accountName string, err error) {
 
 func (j *JWTAuthTokenConfig) keyBytes() (result []byte, err error) {
 	if j.KeyFile != "" {
-		o, err := os.Open(j.KeyFile)
-		if err != nil {
-			return nil, err
-		}
-		defer o.Close()
-		return io.ReadAll(o)
+		return os.ReadFile(j.KeyFile)
 	}
 	if j.KeyString != "" {
 		return []byte(j.KeyString), nil

--- a/irc/jwt/bearer_test.go
+++ b/irc/jwt/bearer_test.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"testing"
+	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 )
@@ -54,7 +55,7 @@ func TestJWTBearerAuth(t *testing.T) {
 			{
 				Algorithm:     "rsa",
 				KeyString:     rsaTestPubKey,
-				AccountClaims: []string{"preferred_username", "email"},
+				AccountClaims: []string{"preferred_username", "email", "account"},
 				StripDomain:   "example.com",
 			},
 		},
@@ -65,7 +66,7 @@ func TestJWTBearerAuth(t *testing.T) {
 	}
 
 	// fixed test vector signed with the RSA privkey:
-	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzbGluZ2FtbiJ9.caPZw2Dl4KZN-SErD5-WZB_lPPveHXaMCoUHxNebb94G9w3VaWDIRdngVU99JKx5nE_yRtpewkHHvXsQnNA_M63GBXGK7afXB8e-kV33QF3v9pXALMP5SzRwMgokyxas0RgHu4e4L0d7dn9o_nkdXp34GX3Pn1MVkUGBH6GdlbOdDHrs04pPQ0Qj-O2U0AIpnZq-X_GQs9ECJo4TlPKWR7Jlq5l9bS0dBnohea4FuqJr232je-dlRVkbCa7nrnFmsIsezsgA3Jb_j9Zu_iv460t_d2eaytbVp9P-DOVfzUfkBsKs-81URQEnTjW6ut445AJz2pxjX92X0GdmORpAkQ"
+	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50Ijoic2xpbmdhbW4iLCJhdWQiOiJodHRwczovL2V4YW1wbGUuY29tL2ZpbGVob3N0IiwiZXhwIjo4MDgzODY1NDkyLCJpc3MiOiJlcmdvLnRlc3QiLCJzcnYiOiJGSUxFSE9TVCJ9.d_tMt4UWuuq3KDgKF4wCyL0tKaeKTCqrKgFZdogOetqmp9qVxi05sMlXawmheWAf3cjQG1ZxCvoc0TovI8H5d5DsVW5txNAXEhYlFKp8Vbd86J04VH2fn32brv5BH9oMPu60bnaEyv_vkKuFMANJzNgQOlMbNTo1IBKYmppi0dVbaBPtylMfL2jTQBwNj6m2_Bv_7N3tf9IgTIRX-Z2VbniHjTB9sEZaFgk6mxj-kwjxqu-lTAxmsPy4H5CBQb-Ea47LBFPmoLt6caxA4VCZyDq1chxcU5DLtv8ec9Sk1XvrGlyWtZ6pD9rT93jpSN6e5r5ceirkvgh20sUIWOOsHg"
 	accountName, err := j.Validate(token)
 	if err != nil {
 		t.Errorf("could not validate valid token: %v", err)
@@ -79,7 +80,8 @@ func TestJWTBearerAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	jTok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"preferred_username": "slingamn"}))
+	exp := time.Now().Add(time.Hour).Unix()
+	jTok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"preferred_username": "slingamn", "exp": exp}))
 	token, err = jTok.SignedString(privKey)
 	if err != nil {
 		t.Fatal(err)
@@ -115,7 +117,7 @@ func TestJWTBearerAuth(t *testing.T) {
 	}
 
 	// test no valid claims
-	jTok = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"sub": "slingamn"}))
+	jTok = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"sub": "slingamn", "exp": exp}))
 	token, err = jTok.SignedString(privKey)
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +129,7 @@ func TestJWTBearerAuth(t *testing.T) {
 	}
 
 	// test email addresses
-	jTok = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"email": "Slingamn@example.com"}))
+	jTok = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"email": "Slingamn@example.com", "exp": exp}))
 	token, err = jTok.SignedString(privKey)
 	if err != nil {
 		t.Fatal(err)

--- a/irc/jwt/bearer_test.go
+++ b/irc/jwt/bearer_test.go
@@ -51,7 +51,7 @@ s/uzBKNwWf9UPTeIt+4JScg=
 func TestJWTBearerAuth(t *testing.T) {
 	j := JWTAuthConfig{
 		Enabled: true,
-		Tokens: []JWTAuthTokenConfig{
+		Tokens: []JWTBearerTokenConfig{
 			{
 				Algorithm:     "rsa",
 				KeyString:     rsaTestPubKey,
@@ -135,7 +135,7 @@ func TestJWTBearerAudValidation(t *testing.T) {
 	key := []byte("MowTTyXKkN58DG2uNMsoCgAa6CM6ElFlcq_7Ocl6wsU")
 	j := JWTAuthConfig{
 		Enabled: true,
-		Tokens: []JWTAuthTokenConfig{
+		Tokens: []JWTBearerTokenConfig{
 			{
 				Algorithm:     "hmac",
 				KeyString:     string(key),

--- a/irc/jwt/bearer_test.go
+++ b/irc/jwt/bearer_test.go
@@ -81,11 +81,7 @@ func TestJWTBearerAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	exp := time.Now().Add(time.Hour).Unix()
-	jTok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"preferred_username": "slingamn", "exp": exp}))
-	token, err = jTok.SignedString(privKey)
-	if err != nil {
-		t.Fatal(err)
-	}
+	token = signTokenForTesting(jwt.SigningMethodRS256, privKey, jwt.MapClaims(map[string]any{"preferred_username": "slingamn", "exp": exp}))
 	accountName, err = j.Validate(token)
 	if err != nil {
 		t.Errorf("could not validate valid token: %v", err)
@@ -95,51 +91,114 @@ func TestJWTBearerAuth(t *testing.T) {
 	}
 
 	// test expiration
-	jTok = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"preferred_username": "slingamn", "exp": 1675740865}))
-	token, err = jTok.SignedString(privKey)
-	if err != nil {
-		t.Fatal(err)
-	}
+	token = signTokenForTesting(jwt.SigningMethodRS256, privKey, jwt.MapClaims(map[string]any{"preferred_username": "slingamn", "exp": 1675740865}))
 	accountName, err = j.Validate(token)
 	if err == nil {
 		t.Errorf("validated expired token")
 	}
 
 	// test for the infamous algorithm confusion bug
-	jTok = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(map[string]any{"preferred_username": "slingamn"}))
-	token, err = jTok.SignedString([]byte(rsaTestPubKey))
-	if err != nil {
-		t.Fatal(err)
-	}
+	token = signTokenForTesting(jwt.SigningMethodHS256, []byte(rsaTestPubKey), jwt.MapClaims(map[string]any{"preferred_username": "slingamn"}))
 	accountName, err = j.Validate(token)
 	if err == nil {
 		t.Errorf("validated HS256 token despite RSA being required")
 	}
 
 	// test no valid claims
-	jTok = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"sub": "slingamn", "exp": exp}))
-	token, err = jTok.SignedString(privKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	token = signTokenForTesting(jwt.SigningMethodRS256, privKey, jwt.MapClaims(map[string]any{"sub": "slingamn", "exp": exp}))
 	accountName, err = j.Validate(token)
 	if err != ErrNoValidAccountClaim {
 		t.Errorf("expected ErrNoValidAccountClaim, got: %v", err)
 	}
 
 	// test email addresses
-	jTok = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(map[string]any{"email": "Slingamn@example.com", "exp": exp}))
-	token, err = jTok.SignedString(privKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	token = signTokenForTesting(jwt.SigningMethodRS256, privKey, jwt.MapClaims(map[string]any{"email": "Slingamn@example.com", "exp": exp}))
 	accountName, err = j.Validate(token)
 	if err != nil {
 		t.Errorf("could not validate valid token: %v", err)
 	}
 	if accountName != "Slingamn" {
 		t.Errorf("incorrect account name for token: `%s`", accountName)
+	}
+}
+
+func signTokenForTesting(method jwt.SigningMethod, key any, claims jwt.MapClaims) (token string) {
+	jTok := jwt.NewWithClaims(method, claims)
+	token, err := jTok.SignedString(key)
+	if err != nil {
+		panic(err)
+	}
+	return token
+}
+
+func TestJWTBearerAudValidation(t *testing.T) {
+	key := []byte("MowTTyXKkN58DG2uNMsoCgAa6CM6ElFlcq_7Ocl6wsU")
+	j := JWTAuthConfig{
+		Enabled: true,
+		Tokens: []JWTAuthTokenConfig{
+			{
+				Algorithm:     "hmac",
+				KeyString:     string(key),
+				AccountClaims: []string{"account"},
+				ValidateAud:   []string{"irc.ergo.chat", "https://irc.ergo.chat"},
+			},
+		},
+	}
+
+	if err := j.Postprocess(); err != nil {
+		t.Fatal(err)
+	}
+
+	exp := time.Now().Add(time.Hour).Unix()
+
+	token := signTokenForTesting(jwt.SigningMethodHS256, key, jwt.MapClaims(map[string]any{"account": "slingamn", "exp": exp}))
+	if _, err := j.Validate(token); err == nil {
+		t.Errorf("validated token with missing aud")
+	}
+
+	token = signTokenForTesting(jwt.SigningMethodHS256, key, jwt.MapClaims(map[string]any{"account": "slingamn", "exp": exp, "aud": "irc.ergo.chat"}))
+	if _, err := j.Validate(token); err != nil {
+		t.Errorf("failed to validate token with string aud: %v", err)
+	}
+
+	token = signTokenForTesting(jwt.SigningMethodHS256, key, jwt.MapClaims(map[string]any{"account": "slingamn", "exp": exp, "aud": "ergo.chat"}))
+	if _, err := j.Validate(token); err == nil {
+		t.Errorf("validated token with invalid string aud")
+	}
+
+	token = signTokenForTesting(jwt.SigningMethodHS256, key, jwt.MapClaims(map[string]any{
+		"account": "slingamn",
+		"exp":     exp,
+		"aud":     []string{"https://example.com", "irc.ergo.chat"},
+	}))
+	if _, err := j.Validate(token); err != nil {
+		t.Errorf("failed to validate token with list aud: %v", err)
+	}
+
+	token = signTokenForTesting(jwt.SigningMethodHS256, key, jwt.MapClaims(map[string]any{
+		"account": "slingamn",
+		"exp":     exp,
+		"aud":     []string{"https://example.com", "ergo.chat"},
+	}))
+	if _, err := j.Validate(token); err == nil {
+		t.Errorf("validated token with invalid list aud")
+	}
+
+	token = signTokenForTesting(jwt.SigningMethodHS256, key, jwt.MapClaims(map[string]any{
+		"account": "slingamn",
+		"exp":     exp,
+		"aud":     make([]string, 0),
+	}))
+	if _, err := j.Validate(token); err == nil {
+		t.Errorf("validated token with invalid list aud")
+	}
+
+	token = signTokenForTesting(jwt.SigningMethodHS256, key, jwt.MapClaims(map[string]any{
+		"account": "slingamn",
+		"exp":     exp,
+		"aud":     []int{1, 2},
+	}))
+	if _, err := j.Validate(token); err == nil {
+		t.Errorf("validated token with invalid list aud")
 	}
 }

--- a/irc/jwt/extjwt.go
+++ b/irc/jwt/extjwt.go
@@ -5,9 +5,11 @@
 package jwt
 
 import (
-	"crypto/rsa"
+	"crypto/ed25519"
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -20,43 +22,80 @@ var (
 type MapClaims jwt.MapClaims
 
 type JwtServiceConfig struct {
-	Expiration        time.Duration
-	Secret            string
-	secretBytes       []byte
-	RSAPrivateKeyFile string `yaml:"rsa-private-key-file"`
-	rsaPrivateKey     *rsa.PrivateKey
+	Expiration    time.Duration
+	Description   string
+	URL           string `yaml:"url"`
+	Algorithm     string `yaml:"algorithm"`
+	KeyString     string `yaml:"key"`
+	KeyFile       string `yaml:"key-file"`
+	signingMethod jwt.SigningMethod
+	signingKey    any
+	verifyKey     any
 }
 
 func (t *JwtServiceConfig) Postprocess() (err error) {
-	t.secretBytes = []byte(t.Secret)
-	t.Secret = ""
-	if t.RSAPrivateKeyFile != "" {
-		keyBytes, err := os.ReadFile(t.RSAPrivateKeyFile)
-		if err != nil {
-			return err
-		}
-		t.rsaPrivateKey, err = jwt.ParseRSAPrivateKeyFromPEM(keyBytes)
-		if err != nil {
-			return err
-		}
+	if t.Algorithm == "" {
+		// disabled
+		return
 	}
+
+	var keyBytes []byte
+	if t.KeyFile != "" {
+		keyBytes, err = os.ReadFile(t.KeyFile)
+		if err != nil {
+			return
+		}
+	} else if t.KeyString != "" {
+		keyBytes = []byte(t.KeyString)
+	} else {
+		return ErrNoKeys
+	}
+
+	switch strings.ToLower(t.Algorithm) {
+	case "hmac":
+		t.signingKey = keyBytes
+		t.verifyKey = keyBytes
+		t.signingMethod = jwt.SigningMethodHS256
+	case "rsa":
+		rsaPrivkey, err := jwt.ParseRSAPrivateKeyFromPEM(keyBytes)
+		if err != nil {
+			return err
+		}
+		t.signingKey = rsaPrivkey
+		t.verifyKey = rsaPrivkey.Public()
+		t.signingMethod = jwt.SigningMethodRS256
+	case "eddsa":
+		ecPrivkey, err := jwt.ParseEdPrivateKeyFromPEM(keyBytes)
+		if err != nil {
+			return err
+		}
+		t.signingKey = ecPrivkey
+		ed25519PrivKey, ok := ecPrivkey.(ed25519.PrivateKey)
+		if !ok {
+			// impossible due to golang-jwt enforcement:
+			return errors.New("unexpected non-ed25519 private key found")
+		}
+		t.verifyKey = ed25519PrivKey.Public()
+		t.signingMethod = jwt.SigningMethodEdDSA
+	default:
+		return fmt.Errorf("invalid JWT algorithm: %s", t.Algorithm)
+	}
+
 	return nil
 }
 
 func (t *JwtServiceConfig) Enabled() bool {
-	return t.Expiration != 0 && (len(t.secretBytes) != 0 || t.rsaPrivateKey != nil)
+	return t.Expiration != 0 && t.signingMethod != nil
 }
 
-func (t *JwtServiceConfig) Sign(claims MapClaims) (result string, err error) {
+func (t *JwtServiceConfig) SignEXTJWT(claims MapClaims) (result string, err error) {
+	if !t.Enabled() {
+		err = ErrNoKeys
+		return
+	}
+
 	claims["exp"] = time.Now().Unix() + int64(t.Expiration/time.Second)
 
-	if t.rsaPrivateKey != nil {
-		token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(claims))
-		return token.SignedString(t.rsaPrivateKey)
-	} else if len(t.secretBytes) != 0 {
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
-		return token.SignedString(t.secretBytes)
-	} else {
-		return "", ErrNoKeys
-	}
+	token := jwt.NewWithClaims(t.signingMethod, jwt.MapClaims(claims))
+	return token.SignedString(t.signingKey)
 }

--- a/irc/jwt/extjwt.go
+++ b/irc/jwt/extjwt.go
@@ -88,6 +88,10 @@ func (t *JwtServiceConfig) Enabled() bool {
 	return t.Expiration != 0 && t.signingMethod != nil
 }
 
+func (t *JwtServiceConfig) verifyKeyFunc(_ *jwt.Token) (key any, err error) {
+	return t.verifyKey, nil
+}
+
 func (t *JwtServiceConfig) SignEXTJWT(claims MapClaims) (result string, err error) {
 	if !t.Enabled() {
 		err = ErrNoKeys

--- a/irc/server.go
+++ b/irc/server.go
@@ -53,6 +53,8 @@ const (
 	chanTypes = "#"
 
 	throttleMessage = "You have attempted to connect too many times within a short duration. Wait a while, and you will be able to connect."
+
+	rawIOWarningMessage = "This server is in debug mode and is logging all user I/O. If you do not wish for everything you send to be readable by the server owner(s), please disconnect."
 )
 
 var (
@@ -537,7 +539,7 @@ func (server *Server) playRegistrationBurst(session *Session) {
 	c.attemptAutoOper(session)
 
 	if server.logger.IsLoggingRawIO() {
-		session.Send(nil, c.server.name, "NOTICE", d.nick, c.t("This server is in debug mode and is logging all user I/O. If you do not wish for everything you send to be readable by the server owner(s), please disconnect."))
+		session.Send(nil, c.server.name, "NOTICE", d.nick, c.t(rawIOWarningMessage))
 	}
 }
 
@@ -904,8 +906,10 @@ func (server *Server) applyConfig(config *Config) (err error) {
 
 	// set RPL_ISUPPORT
 	var newISupportReplies [][]string
+	var authTokenDiff [][]string
 	if oldConfig != nil {
 		newISupportReplies = oldConfig.Server.isupport.GetDifference(&config.Server.isupport)
+		authTokenDiff = oldConfig.AuthToken.GetDifference(config.AuthToken)
 	}
 
 	if len(config.Server.ProxyAllowedFrom) != 0 {
@@ -920,21 +924,25 @@ func (server *Server) applyConfig(config *Config) (err error) {
 		sdnotify.Ready()
 	}
 
-	if !initial {
-		// send 005 updates (somewhat rare)
-		if len(newISupportReplies) != 0 {
-			for _, sClient := range server.clients.AllClients() {
-				for _, session := range sClient.Sessions() {
-					rb := NewResponseBuffer(session)
+	if !initial && (len(newISupportReplies) > 0 || len(authTokenDiff) > 0) {
+		for _, sClient := range server.clients.AllClients() {
+			for _, session := range sClient.Sessions() {
+				rb := NewResponseBuffer(session)
+				if len(newISupportReplies) > 0 {
 					server.sendRplISupportLines(sClient, rb, newISupportReplies)
-					rb.Send(false)
 				}
+				if len(authTokenDiff) > 0 && session.capabilities.Has(caps.AuthToken) {
+					for _, line := range authTokenDiff {
+						rb.Add(nil, server.name, "TOKEN", line...)
+					}
+				}
+				rb.Send(false)
 			}
 		}
 
 		if sendRawOutputNotice {
 			for _, sClient := range server.clients.AllClients() {
-				sClient.Notice(sClient.t("This server is in debug mode and is logging all user I/O. If you do not wish for everything you send to be readable by the server owner(s), please disconnect."))
+				sClient.Notice(sClient.t(rawIOWarningMessage))
 			}
 		}
 	}

--- a/irc/server.go
+++ b/irc/server.go
@@ -514,6 +514,9 @@ func (server *Server) playRegistrationBurst(session *Session) {
 	if d.account != "" && session.capabilities.Has(caps.Persistence) {
 		reportPersistenceStatus(c, rb, false)
 	}
+	if session.capabilities.Has(caps.AuthToken) {
+		tokenServicelistHandler(server, config, c, rb)
+	}
 	server.Lusers(c, rb)
 	server.MOTD(c, rb)
 	rb.Send(true)

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -1002,11 +1002,11 @@ extjwt:
     # # expiration time for the token:
     # expiration: 45s
     # algorithm: "hmac" # either 'hmac', 'rsa', or 'eddsa' (ed25519)
-    # # hmac takes a symmetric key, rsa and eddsa take PEM-encoded public keys;
+    # # hmac takes a symmetric key, rsa and eddsa take PEM-encoded private keys;
     # # either way, the key can be specified either as a YAML string:
     # key: "nANiZ1De4v6WnltCHN2H7Q"
     # # or as a path to the file containing the key:
-    # #key-file: "jwt_pubkey.pem"
+    # #key-file: "jwt_privkey.pem"
 
     # # named services (for `EXTJWT #channel service_name`):
     # services:

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -291,6 +291,8 @@ server:
         # constant list of args to pass to the command; the actual query
         # and result are transmitted over stdin/stdout:
         args: []
+        # alternatively, pass the input to a persistent process over unix domain socket:
+        #socket: "/tmp/ergo_ip_check_sidecar"
         # timeout for process execution, after which we send a SIGTERM:
         timeout: 9s
         # how long after the SIGTERM before we follow up with a SIGKILL:
@@ -589,6 +591,8 @@ accounts:
         # constant list of args to pass to the command; the actual authentication
         # data is transmitted over stdin/stdout:
         args: []
+        # alternatively, pass the input to a persistent process over unix domain socket:
+        #socket: "/tmp/ergo_auth_sidecar"
         # should we automatically create users if the plugin returns success?
         autocreate: true
         # timeout for process execution, after which we send a SIGTERM:
@@ -994,16 +998,34 @@ extjwt:
     # # default service config (for `EXTJWT #channel`).
     # # expiration time for the token:
     # expiration: 45s
-    # # you can configure tokens to be signed either with HMAC and a symmetric secret:
-    # secret: "65PHvk0K1_sM-raTsCEhatVkER_QD8a0zVV8gG2EWcI"
-    # # or with an RSA private key:
-    # #rsa-private-key-file: "extjwt.pem"
+    # algorithm: "hmac" # either 'hmac', 'rsa', or 'eddsa' (ed25519)
+    # # hmac takes a symmetric key, rsa and eddsa take PEM-encoded public keys;
+    # # either way, the key can be specified either as a YAML string:
+    # key: "nANiZ1De4v6WnltCHN2H7Q"
+    # # or as a path to the file containing the key:
+    # #key-file: "jwt_pubkey.pem"
 
     # # named services (for `EXTJWT #channel service_name`):
     # services:
     #     "jitsi":
     #         expiration: 30s
-    #         secret: "qmamLKDuOzIzlO8XqsGGewei_At11lewh6jtKfSTbkg"
+    #         algorithm: "hmac"
+    #         key: "qmamLKDuOzIzlO8XqsGGewei_At11lewh6jtKfSTbkg"
+
+# experimental draft/AUTHTOKEN mechanism
+authtoken:
+    enabled: false
+
+    # only these IPs can verify tokens
+    verification-ip-whitelist:
+        - "localhost"
+
+    #services:
+    #   "FILEHOST":
+    #       expiration: 5m
+    #       url: "https://example.com/filehost"
+    #       algorithm: "eddsa"
+    #       key: "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIHfpO1x835o9NIQA1kBkN7/Myd6wqE/m/EYJUHBC18hW\n-----END PRIVATE KEY-----"
 
 # history message storage: this is used by CHATHISTORY, HISTORY, znc.in/playback,
 # various autoreplay features, and the resume extension

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -635,6 +635,9 @@ accounts:
                 # if a claim is formatted as an email address, require it to have the following domain,
                 # and then strip off the domain and use the local-part as the account name:
                 #strip-domain: "example.com"
+                # optional list of `aud` claims that are acceptable
+                # (if omitted, the aud claim is not validated):
+                #validate-aud: ["irc.mydomain.com"]
 
 # channel options
 channels:


### PR DESCRIPTION
cc @whitequark @skizzerz

This implements the preliminary version of draft/AUTHTOKEN that I saw. The design here is the planned Ergo implementation: Ergo will GENERATE stateless JWTs, and implement VALIDATE over IRC C2S (and VALIDATE will pull some amount of additional live data to populate claims), but the intent is for Ergo-aware systems to parse and validate the token themselves without calling VALIDATE.

I wrote this code by hand, then had Claude Sonnet 4.6 review it against the spec. It didn't find any sharp edges with the JWT code, but it flagged some discrepancies with the spec:

1. Will `VALIDATE` take the service as one of its arguments or not? (This implementation assumes `VALIDATE` with no service parameter, just the token; the service name is encoded in the token and signed.)
2. Are `GENERATE` and `SERVICELIST` available before connection registration? `GENERATE` seems not useful in that context. `SERVICELIST` seems potentially useful but would introduce additional security considerations for Ergo (for example, on a password-protected or `require-sasl` deployment we would want to hide it).
3. I implemented an IP whitelist for `VALIDATE` pre-registration (actually after registration too, but that's not really a concern). The user can enable `0.0.0.0/0` and `::/0` if they need to, but I wanted to make sure that restrictions on who can `VALIDATE` aren't going against the spirit of the spec.

Thanks!