### PR TITLE
pointless optimization to (*caps.Set).Strings

### DIFF
--- a/irc/caps/set.go
+++ b/irc/caps/set.go
@@ -5,6 +5,7 @@ package caps
 
 import (
 	"fmt"
+
 	"github.com/ergochat/ergo/irc/utils"
 )
 
@@ -99,8 +100,10 @@ func (s *Set) Strings(version Version, values Values, maxLen int) (result []stri
 	var t utils.TokenLineBuilder
 	t.Initialize(maxLen, " ")
 
+	var local Set
+	asSlice := local[:]
+	utils.BitsetCopyLocal(asSlice, s[:])
 	var capab Capability
-	asSlice := s[:]
 	for capab = 0; capab < numCapabs; capab++ {
 		// XXX clients that only support CAP LS 301 cannot handle multiline
 		// responses. omit some CAPs in this case, forcing the response to fit on
@@ -110,7 +113,7 @@ func (s *Set) Strings(version Version, values Values, maxLen int) (result []stri
 			continue
 		}
 		// skip any capabilities that are not enabled
-		if !utils.BitsetGet(asSlice, uint(capab)) {
+		if !utils.BitsetGetLocal(asSlice, uint(capab)) {
 			continue
 		}
 		capString := capab.Name()

--- a/irc/caps/set_test.go
+++ b/irc/caps/set_test.go
@@ -107,3 +107,14 @@ func BenchmarkSetWrites(b *testing.B) {
 		set.Remove(LabeledResponse)
 	}
 }
+
+func BenchmarkSetStrings(b *testing.B) {
+	set := NewSet()
+	set.Add(AccountNotify)
+	set.Add(ZNCPlayback)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		set.Strings(Cap302, nil, 400)
+	}
+}

--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -346,9 +346,13 @@ func (set *ModeSet) AllModes() (result []Mode) {
 		return
 	}
 
+	var local ModeSet
+	asSlice := local[:]
+	utils.BitsetCopyLocal(asSlice, set[:])
+
 	var i Mode
 	for i = minMode; i <= maxMode; i++ {
-		if set.HasMode(i) {
+		if utils.BitsetGetLocal(asSlice, uint(i)-minMode) {
 			result = append(result, i)
 		}
 	}


### PR DESCRIPTION
Doesn't change anything on arm64 (where atomic load is a plain MOV), but reduces atomic instructions on arm64.

Reviewed by Sonnet 4.6, no issues found.