### PR TITLE
fix(labeled-response): label client-initiated QUIT instead of empty ACK

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -201,6 +201,7 @@ type Session struct {
 	isupportSentPrereg bool
 
 	quitMessage string
+	quitLabel   string // labeled-response label to attach to the final QUIT line
 
 	awayMessage string
 	awayAt      time.Time
@@ -1244,6 +1245,20 @@ func (client *Client) LoggedIntoAccount() bool {
 }
 
 // Quit sets the given quit message for the client.
+// makeClientQuitLine builds the QUIT line sent to a session as its connection closes,
+// attaching server-time and (for a client-initiated QUIT) the labeled-response label.
+func makeClientQuitLine(sess *Session, nuh, message string, now time.Time) ircmsg.Message {
+	quitMsg := ircmsg.MakeMessage(nil, nuh, "QUIT", message)
+	if sess.capabilities.Has(caps.ServerTime) {
+		quitMsg.SetTag("time", now.Format(utils.IRCv3TimestampFormat))
+	}
+	// #2402: a client-initiated QUIT is the labeled response to its own command
+	if sess.quitLabel != "" && sess.capabilities.Has(caps.LabeledResponse) {
+		quitMsg.SetTag(caps.LabelTagName, sess.quitLabel)
+	}
+	return quitMsg
+}
+
 // (You must ensure separately that destroy() is called, e.g., by returning `true` from
 // the command handler or calling it yourself.)
 func (client *Client) Quit(message string, session *Session) {
@@ -1255,10 +1270,7 @@ func (client *Client) Quit(message string, session *Session) {
 		var finalData []byte
 		// #364: don't send QUIT lines to unregistered clients
 		if client.registered {
-			quitMsg := ircmsg.MakeMessage(nil, nuh, "QUIT", message)
-			if sess.capabilities.Has(caps.ServerTime) {
-				quitMsg.SetTag("time", now.Format(utils.IRCv3TimestampFormat))
-			}
+			quitMsg := makeClientQuitLine(sess, nuh, message, now)
 			finalData, _ = quitMsg.LineBytesStrict(false, MaxLineLen)
 		}
 

--- a/irc/client_test.go
+++ b/irc/client_test.go
@@ -6,10 +6,42 @@ package irc
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/ergochat/ergo/irc/caps"
 	"github.com/ergochat/ergo/irc/languages"
 	"github.com/ergochat/ergo/irc/utils"
 )
+
+func TestClientQuitLineLabeled(t *testing.T) {
+	nuh := "foo!~user@127.0.0.1"
+	now := time.Now().UTC()
+
+	// #2402: a client-initiated QUIT must carry the labeled-response label
+	var labeled Session
+	labeled.capabilities.Enable(caps.LabeledResponse)
+	labeled.quitLabel = "deadbeef"
+	quitMsg := makeClientQuitLine(&labeled, nuh, "Quit: foo out", now)
+	if _, value := quitMsg.GetTag(caps.LabelTagName); value != "deadbeef" {
+		t.Errorf("expected QUIT line to carry label deadbeef, got %q", value)
+	}
+
+	// a QUIT with no pending label must not be tagged
+	var unlabeled Session
+	unlabeled.capabilities.Enable(caps.LabeledResponse)
+	quitMsg = makeClientQuitLine(&unlabeled, nuh, "Quit: foo out", now)
+	if quitMsg.HasTag(caps.LabelTagName) {
+		t.Error("QUIT line without a pending label must not carry a label tag")
+	}
+
+	// a label must not be attached if the session lacks the labeled-response cap
+	var noCap Session
+	noCap.quitLabel = "deadbeef"
+	quitMsg = makeClientQuitLine(&noCap, nuh, "Quit: foo out", now)
+	if quitMsg.HasTag(caps.LabelTagName) {
+		t.Error("QUIT line must not carry a label tag without the labeled-response cap")
+	}
+}
 
 func TestGenerateBatchID(t *testing.T) {
 	var session Session

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2964,6 +2964,9 @@ func quitHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 	if len(msg.Params) > 0 {
 		reason += ": " + msg.Params[0]
 	}
+	// #2402: the final QUIT line carries the label; don't also emit a labeled ACK
+	rb.session.quitLabel = rb.Label
+	rb.Label = ""
 	client.Quit(reason, rb.session)
 	return true
 }


### PR DESCRIPTION
A labeled QUIT currently produces a labeled `ACK` (because the QUIT line is sent as socket final data and bypasses the response buffer) followed by an unlabeled QUIT, instead of putting the label on the QUIT itself. This attaches the label tag to the client-initiated QUIT line and suppresses the spurious ACK.

Closes #2402