### PR TITLE
filter secret channels from unprivileged NS INFO

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1926,7 +1926,7 @@ func (am *AccountManager) Unregister(account string, erase bool) error {
 
 	// on our way out, unregister all the account's channels and delete them from the db
 	defer func() {
-		for _, channelName := range am.server.channels.ChannelsForAccount(casefoldedAccount) {
+		for _, channelName := range am.server.channels.ChannelsForAccount(casefoldedAccount, true) {
 			err := am.server.channels.SetUnregistered(channelName, casefoldedAccount)
 			if err != nil {
 				am.server.logger.Error("internal", "couldn't unregister channel", channelName, err.Error())

--- a/irc/api.go
+++ b/irc/api.go
@@ -287,7 +287,7 @@ func (a *ergoAPI) handleAccountDetails(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Get channels the account is in
-			response.Channels = a.server.channels.ChannelsForAccount(accountData.NameCasefolded)
+			response.Channels = a.server.channels.ChannelsForAccount(accountData.NameCasefolded, true)
 			response.Success = true
 		case errAccountDoesNotExist, errAccountUnverified, errAccountSuspended:
 			response.Success = false

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ergochat/ergo/irc/datastore"
+	"github.com/ergochat/ergo/irc/modes"
 	"github.com/ergochat/ergo/irc/utils"
 )
 
@@ -487,13 +488,15 @@ func (cm *ChannelManager) LoadPurgeRecord(cfchname string) (record ChannelPurgeR
 	}
 }
 
-func (cm *ChannelManager) ChannelsForAccount(account string) (channels []string) {
+func (cm *ChannelManager) ChannelsForAccount(account string, isPrivileged bool) (channels []string) {
 	cm.RLock()
 	defer cm.RUnlock()
 
 	for cfname, entry := range cm.chans {
 		if entry.channel.Founder() == account {
-			channels = append(channels, cfname)
+			if isPrivileged || !entry.channel.flags.HasMode(modes.Secret) {
+				channels = append(channels, cfname)
+			}
 		}
 	}
 

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -460,7 +460,7 @@ func csRegisterHandler(service *ircService, server *Server, client *Client, comm
 // check whether a client has already registered too many channels
 func checkChanLimit(service *ircService, client *Client, rb *ResponseBuffer) (ok bool) {
 	account := client.Account()
-	channelsAlreadyRegistered := client.server.channels.ChannelsForAccount(account)
+	channelsAlreadyRegistered := client.server.channels.ChannelsForAccount(account, true)
 	ok = len(channelsAlreadyRegistered) < client.server.Config().Channels.Registration.MaxChannelsPerAccount || client.HasRoleCapabs("chanreg")
 	if !ok {
 		service.Notice(rb, client.t("You have already registered the maximum number of channels; try dropping some with /CS UNREGISTER"))
@@ -755,7 +755,7 @@ func csListHandler(service *ircService, server *Server, client *Client, command 
 func csInfoHandler(service *ircService, server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
 	if len(params) == 0 {
 		// #765
-		listRegisteredChannels(service, client.Account(), rb)
+		listRegisteredChannels(service, client.Account(), true, rb)
 		return
 	}
 

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -948,9 +948,9 @@ func nsInfoHandler(service *ircService, server *Server, client *Client, command 
 	registeredAt := account.RegisteredAt.Format(time.RFC1123)
 	service.Notice(rb, fmt.Sprintf(client.t("Registered at: %s"), registeredAt))
 
-	isPrivileged := account.Name == client.AccountName() || client.HasRoleCapabs("accreg")
+	isSelf := account.Name == client.AccountName()
 
-	if isPrivileged {
+	if isSelf || client.HasRoleCapabs("accreg") {
 		if account.Settings.Email != "" {
 			service.Notice(rb, fmt.Sprintf(client.t("Email address: %s"), account.Settings.Email))
 		}
@@ -960,7 +960,7 @@ func nsInfoHandler(service *ircService, server *Server, client *Client, command 
 	for _, nick := range account.AdditionalNicks {
 		service.Notice(rb, fmt.Sprintf(client.t("Additional grouped nick: %s"), nick))
 	}
-	listRegisteredChannels(service, accountName, isPrivileged, rb)
+	listRegisteredChannels(service, accountName, (isSelf || client.HasRoleCapabs("sajoin")), rb)
 	if account.Suspended != nil {
 		service.Notice(rb, suspensionToString(client, *account.Suspended))
 	}

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -948,7 +948,9 @@ func nsInfoHandler(service *ircService, server *Server, client *Client, command 
 	registeredAt := account.RegisteredAt.Format(time.RFC1123)
 	service.Notice(rb, fmt.Sprintf(client.t("Registered at: %s"), registeredAt))
 
-	if account.Name == client.AccountName() || client.HasRoleCapabs("accreg") {
+	isPrivileged := account.Name == client.AccountName() || client.HasRoleCapabs("accreg")
+
+	if isPrivileged {
 		if account.Settings.Email != "" {
 			service.Notice(rb, fmt.Sprintf(client.t("Email address: %s"), account.Settings.Email))
 		}
@@ -958,15 +960,15 @@ func nsInfoHandler(service *ircService, server *Server, client *Client, command 
 	for _, nick := range account.AdditionalNicks {
 		service.Notice(rb, fmt.Sprintf(client.t("Additional grouped nick: %s"), nick))
 	}
-	listRegisteredChannels(service, accountName, rb)
+	listRegisteredChannels(service, accountName, isPrivileged, rb)
 	if account.Suspended != nil {
 		service.Notice(rb, suspensionToString(client, *account.Suspended))
 	}
 }
 
-func listRegisteredChannels(service *ircService, accountName string, rb *ResponseBuffer) {
+func listRegisteredChannels(service *ircService, accountName string, isPrivileged bool, rb *ResponseBuffer) {
 	client := rb.session.client
-	channels := client.server.channels.ChannelsForAccount(accountName)
+	channels := client.server.channels.ChannelsForAccount(accountName, isPrivileged)
 	service.Notice(rb, fmt.Sprintf(client.t("Account %s has %d registered channel(s)."), accountName, len(channels)))
 	for _, channel := range channels {
 		service.Notice(rb, fmt.Sprintf(client.t("Registered channel: %s"), channel))


### PR DESCRIPTION
Reported by dzwdz from irc.ergo.chat. This is a security issue but not serious enough to embargo.

Handwritten, reviewed by Sonnet 4.6, no issues found.