### PR TITLE
fix #2411: split long CAP ACK/NAK across multiple lines

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -733,7 +733,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 	sendCapReqResponse := func(response string) {
 		// :server.name CAP nickname ACK :list of caps\r\n
 		maxLen := (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 6
-		if len(capString) <= maxLen {
+		if len(capString) <= maxLen || len(capFields) == 0 {
 			rb.Add(nil, server.name, "CAP", details.nick, response, capString)
 			return
 		}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -700,22 +700,47 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		}
 	}
 
+	// budget for the token payload of a `:server.name CAP nickname <subcmd> * :<tokens>` line
+	capMaxLen := func(replySubCommand string) int {
+		// :server.name CAP nickname LS * :<tokens>\r\n
+		// 1           [5  ]        1  [4 ]        [2 ]
+		return (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 1 - len(replySubCommand) - 4
+	}
+
 	sendCapLines := func(cset *caps.Set, values caps.Values) {
 		version := rb.session.capVersion
 		// we're working around two bugs:
 		// 1. WeeChat 1.4 won't accept the CAP reply unless it contains the server.name source
 		// 2. old versions of Kiwi and The Lounge can't parse multiline CAP LS 302 (#661),
 		// so try as hard as possible to get the response to fit on one line.
-		// :server.name CAP nickname LS * :<tokens>\r\n
-		// 1           [5  ]        1  [4 ]        [2 ]
-		maxLen := (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 1 - len(subCommand) - 4
-		capLines := cset.Strings(version, values, maxLen)
+		capLines := cset.Strings(version, values, capMaxLen(subCommand))
 		for i, capStr := range capLines {
 			if version >= caps.Cap302 && i < len(capLines)-1 {
 				rb.Add(nil, server.name, "CAP", details.nick, subCommand, "*", capStr)
 			} else {
 				rb.Add(nil, server.name, "CAP", details.nick, subCommand, capStr)
 			}
+		}
+	}
+
+	// send a CAP ACK or NAK that echoes back the client-supplied cap string (#2411).
+	// the string can approach the 512-byte line limit, so split it across multiple
+	// lines rather than letting it be truncated. per the CAP negotiation spec, ACK
+	// may be spread across multiple lines (the client applies the change only after
+	// the final ACK); the `*` continuation marker is defined only for LS/LIST, so it
+	// is not used here.
+	sendCapReqResponse := func(response, capString string) {
+		var t utils.TokenLineBuilder
+		t.Initialize(capMaxLen(response), " ")
+		for _, token := range strings.Fields(capString) {
+			t.Add(token)
+		}
+		capLines := t.Lines()
+		if capLines == nil {
+			capLines = []string{capString}
+		}
+		for _, capStr := range capLines {
+			rb.Add(nil, server.name, "CAP", details.nick, response, capStr)
 		}
 	}
 
@@ -747,7 +772,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		// every offered capability. during registration, requesting it produces a quit,
 		// otherwise just a CAP NAK
 		if badCaps || (toAdd.Has(caps.Nope) && client.registered) {
-			rb.Add(nil, server.name, "CAP", details.nick, "NAK", capString)
+			sendCapReqResponse("NAK", capString)
 			return false
 		} else if toAdd.Has(caps.Nope) && !client.registered {
 			client.Quit(fmt.Sprintf(client.t("Requesting the %s client capability is forbidden"), caps.Nope.Name()), rb.session, nil)
@@ -756,7 +781,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 
 		rb.session.capabilities.Union(toAdd)
 		rb.session.capabilities.Subtract(toRemove)
-		rb.Add(nil, server.name, "CAP", details.nick, "ACK", capString)
+		sendCapReqResponse("ACK", capString)
 
 	case "END":
 		if !client.registered {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -676,7 +676,6 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 	subCommand := strings.ToUpper(msg.Params[0])
 	toAdd := caps.NewSet()
 	toRemove := caps.NewSet()
-	var capString string
 
 	config := server.Config()
 	supportedCaps := config.Server.supportedCaps
@@ -687,10 +686,12 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 	}
 
 	badCaps := false
+	var capString string
+	var capFields []string
 	if len(msg.Params) > 1 {
 		capString = msg.Params[1]
-		strs := strings.Fields(capString)
-		for _, str := range strs {
+		capFields = strings.Fields(capString)
+		for _, str := range capFields {
 			remove := false
 			if str[0] == '-' {
 				str = str[1:]
@@ -729,7 +730,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 	// CAP ACK / CAP NAK may also overflow the 512-byte limit, so we may need
 	// to split it. Unlike LS / LIST, each ACK and NAK is processed independently
 	// and there is no line continuation form
-	sendCapReqResponse := func(response, capString string) {
+	sendCapReqResponse := func(response string) {
 		// :server.name CAP nickname ACK :list of caps\r\n
 		maxLen := (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 6
 		if len(capString) <= maxLen {
@@ -738,7 +739,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		}
 		var t utils.TokenLineBuilder
 		t.Initialize(maxLen, " ")
-		for _, token := range strings.Fields(capString) {
+		for _, token := range capFields {
 			t.Add(token)
 		}
 		capLines := t.Lines()
@@ -775,7 +776,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		// every offered capability. during registration, requesting it produces a quit,
 		// otherwise just a CAP NAK
 		if badCaps || (toAdd.Has(caps.Nope) && client.registered) {
-			sendCapReqResponse("NAK", capString)
+			sendCapReqResponse("NAK")
 			return false
 		} else if toAdd.Has(caps.Nope) && !client.registered {
 			client.Quit(fmt.Sprintf(client.t("Requesting the %s client capability is forbidden"), caps.Nope.Name()), rb.session, nil)
@@ -784,7 +785,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 
 		rb.session.capabilities.Union(toAdd)
 		rb.session.capabilities.Subtract(toRemove)
-		sendCapReqResponse("ACK", capString)
+		sendCapReqResponse("ACK")
 
 		// XXX compatibility hack, if draft/metadata-2 was requested, silently enable draft/metadata-3
 		// this way we only have to check for one cap at runtime

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -700,20 +700,16 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		}
 	}
 
-	// budget for the token payload of a `:server.name CAP nickname <subcmd> * :<tokens>` line
-	capMaxLen := func(replySubCommand string) int {
-		// :server.name CAP nickname LS * :<tokens>\r\n
-		// 1           [5  ]        1  [4 ]        [2 ]
-		return (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 1 - len(replySubCommand) - 4
-	}
-
 	sendCapLines := func(cset *caps.Set, values caps.Values) {
 		version := rb.session.capVersion
 		// we're working around two bugs:
 		// 1. WeeChat 1.4 won't accept the CAP reply unless it contains the server.name source
 		// 2. old versions of Kiwi and The Lounge can't parse multiline CAP LS 302 (#661),
 		// so try as hard as possible to get the response to fit on one line.
-		capLines := cset.Strings(version, values, capMaxLen(subCommand))
+		// :server.name CAP nickname LS * :<tokens>\r\n
+		// 1           [5  ]        1  [4 ]        [2 ]
+		maxLen := (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 1 - len(subCommand) - 4
+		capLines := cset.Strings(version, values, maxLen)
 		for i, capStr := range capLines {
 			if version >= caps.Cap302 && i < len(capLines)-1 {
 				rb.Add(nil, server.name, "CAP", details.nick, subCommand, "*", capStr)
@@ -723,22 +719,22 @@ func capHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 		}
 	}
 
-	// send a CAP ACK or NAK that echoes back the client-supplied cap string (#2411).
-	// the string can approach the 512-byte line limit, so split it across multiple
-	// lines rather than letting it be truncated. per the CAP negotiation spec, ACK
-	// may be spread across multiple lines (the client applies the change only after
-	// the final ACK); the `*` continuation marker is defined only for LS/LIST, so it
-	// is not used here.
+	// CAP ACK / CAP NAK may also overflow the 512-byte limit, so we may need
+	// to split it. Unlike LS / LIST, each ACK and NAK is processed independently
+	// and there is no line continuation form
 	sendCapReqResponse := func(response, capString string) {
+		// :server.name CAP nickname ACK :list of caps\r\n
+		maxLen := (MaxLineLen - 2) - 1 - len(server.name) - 5 - len(details.nick) - 6
+		if len(capString) <= maxLen {
+			rb.Add(nil, server.name, "CAP", details.nick, response, capString)
+			return
+		}
 		var t utils.TokenLineBuilder
-		t.Initialize(capMaxLen(response), " ")
+		t.Initialize(maxLen, " ")
 		for _, token := range strings.Fields(capString) {
 			t.Add(token)
 		}
 		capLines := t.Lines()
-		if capLines == nil {
-			capLines = []string{capString}
-		}
 		for _, capStr := range capLines {
 			rb.Add(nil, server.name, "CAP", details.nick, response, capStr)
 		}


### PR DESCRIPTION
For CAP REQ we echo the client's cap string back in the ACK (or NAK), so a long enough request can push the reply past the 512-byte line limit and get truncated.

This splits the echoed cap string into multiple lines that fit the budget, reusing the same TokenLineBuilder and length accounting as the LS/LIST path. The spec's `*` continuation marker only applies to LS/LIST, so ACK/NAK use plain multi-line replies (ACK is allowed to span multiple lines, with the client applying the change after the final one).

The token-splitting itself is covered by the existing TokenLineBuilder tests; exercising capHandler directly would need a full server/session/ResponseBuffer harness that isn't present here.