### PR TITLE
fix TestEmptyBuffer flakiness from timestamp collisions on coarse clocks

### DIFF
--- a/irc/history/history_test.go
+++ b/irc/history/history_test.go
@@ -24,9 +24,7 @@ func TestEmptyBuffer(t *testing.T) {
 
 	buf := NewHistoryBuffer(0, 0)
 
-	buf.Add(Item{
-		Nick: "testnick",
-	})
+	buf.Add(easyItem("testnick", "2006-01-03 15:04:05Z"))
 
 	since, complete := betweenTimestamps(buf, pastTime, time.Now(), 0)
 	if len(since) != 0 {
@@ -40,9 +38,7 @@ func TestEmptyBuffer(t *testing.T) {
 	since, complete = betweenTimestamps(buf, pastTime, time.Now(), 0)
 	assertEqual(complete, true, t)
 	assertEqual(len(since), 0, t)
-	buf.Add(Item{
-		Nick: "testnick",
-	})
+	buf.Add(easyItem("testnick", "2006-01-03 15:04:05Z"))
 	since, complete = betweenTimestamps(buf, pastTime, time.Now(), 0)
 	if len(since) != 1 {
 		t.Error("should be able to store items in a nonempty buffer")
@@ -54,9 +50,7 @@ func TestEmptyBuffer(t *testing.T) {
 		t.Error("retrived junk data")
 	}
 
-	buf.Add(Item{
-		Nick: "testnick2",
-	})
+	buf.Add(easyItem("testnick2", "2006-01-04 15:04:05Z"))
 	since, complete = betweenTimestamps(buf, pastTime, time.Now(), 0)
 	if len(since) != 1 {
 		t.Error("expect exactly 1 item")


### PR DESCRIPTION
## Problem

`go test ./irc/history/ -run TestEmptyBuffer` panics on macOS (reliably so on Apple Silicon):

```
history_test.go:48: should be able to store items in a nonempty buffer
panic: runtime error: index out of range [0] with length 0
	history_test.go:53
```

## Root cause

TestEmptyBuffer was the only test in the file that added items without an explicit `Message.Time`, letting `Add()` stamp them with `time.Now().UTC()`, and then immediately queried with `end = time.Now()` as the upper bound. `betweenHelper` uses strictly exclusive bounds (`item.Message.Time.Before(before)`), consistent with CHATHISTORY `BETWEEN` semantics.

On macOS, Go's wall clock ticks in 1µs increments (nanoseconds are always multiples of 1000), and ~95% of back-to-back `time.Now()` calls return the *identical* wall time. So the item's timestamp equals the query bound, the strict `Before` check excludes it, and the test panics indexing the empty result slice. Linux's nanosecond-resolution clock is why CI never sees this; on fast Apple Silicon machines the failure is nearly deterministic. (Verified identical behavior on go1.25 and go1.26 — not a Go regression, just a latent race against clock granularity.)

The ring buffer itself behaves correctly; this is purely a test bug.

## Fix

Use explicit fixed timestamps via the existing `easyItem` helper, matching every other test in this file. The query's `time.Now()` upper bound is unchanged — the 2006-dated items are now unambiguously inside the window regardless of clock resolution.

Verified with `go test ./irc/history/ -count=50` and `-race` on darwin/arm64.