### PR TITLE
fix #2431

### DIFF
--- a/irc/server.go
+++ b/irc/server.go
@@ -478,12 +478,6 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 		server.handleAutojoins(session, config.Channels.AutoJoin)
 	}
 
-	if session.capabilities.Has(caps.Metadata) {
-		rb := NewResponseBuffer(session)
-		syncAllMetadata(server, rb)
-		rb.Send(true)
-	}
-
 	return false
 }
 


### PR DESCRIPTION
Remove metadata sync batch sent to non-persistent clients, since (ignoring autojoin because it's deprecated) a newly created non-persistent client has no channels, so the sync will always either be empty or redundant with the list of the client's own metadata sent in playRegistrationBurst. In contrast, the metadata sync for persistent clients in (*Client).performReattach actually does something, since persistent clients are already in channels.