### PR TITLE
Log source IP on failed OPER, SASL, and NickServ IDENTIFY attempts

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -335,7 +335,8 @@ func authIRCv3BearerHandler(server *Server, client *Client, session *Session, va
 
 func sendAuthErrorResponse(client *Client, rb *ResponseBuffer, err error) {
 	msg := authErrorToMessage(client.server, err)
-	client.server.logger.Info("accounts", rb.session.ConnID(), "failed SASL authentication", "from IP", rb.session.IP().String())
+	client.server.logger.Info("accounts", rb.session.ConnID(), "failed SASL authentication")
+	client.server.logger.Info("connect-ip", rb.session.ConnID(), "failed SASL authentication from", rb.session.IP().String())
 	rb.Add(nil, client.server.name, ERR_SASLFAIL, client.nick, fmt.Sprintf("%s: %s", client.t("SASL authentication failed"), client.t(msg)))
 	if err == errAccountUnverified {
 		rb.Add(nil, client.server.name, "NOTE", "AUTHENTICATE", "VERIFICATION_REQUIRED", "*", client.t(err.Error()))
@@ -2724,16 +2725,22 @@ func operHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 
 		// hopefully not too spammy given the throttling:
 		ip := rb.session.IP().String()
+		var reason string
 		if oper == nil {
-			server.logger.Info("opers", "OPER failed with invalid oper name", msg.Params[0], "from IP", ip)
+			reason = "invalid oper name"
+			server.logger.Info("opers", "OPER failed with invalid oper name", msg.Params[0])
 		} else if certFailed {
-			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid certfp", "from IP", ip)
+			reason = "invalid certfp"
+			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid certfp")
 		} else if passwordFailed {
-			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid password", "from IP", ip)
+			reason = "invalid password"
+			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid password")
 		} else {
 			// should not be possible given config validation
-			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid config", "from IP", ip)
+			reason = "invalid config"
+			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid config")
 		}
+		server.logger.Info("connect-ip", rb.session.ConnID(), "OPER attempt for", msg.Params[0], "failed with", reason, "from", ip)
 
 		return false
 	}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -335,6 +335,7 @@ func authIRCv3BearerHandler(server *Server, client *Client, session *Session, va
 
 func sendAuthErrorResponse(client *Client, rb *ResponseBuffer, err error) {
 	msg := authErrorToMessage(client.server, err)
+	client.server.logger.Info("accounts", rb.session.ConnID(), "failed SASL authentication", "from IP", rb.session.IP().String())
 	rb.Add(nil, client.server.name, ERR_SASLFAIL, client.nick, fmt.Sprintf("%s: %s", client.t("SASL authentication failed"), client.t(msg)))
 	if err == errAccountUnverified {
 		rb.Add(nil, client.server.name, "NOTE", "AUTHENTICATE", "VERIFICATION_REQUIRED", "*", client.t(err.Error()))
@@ -2722,15 +2723,16 @@ func operHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 		rb.Add(nil, server.name, ERR_NOOPERHOST, client.Nick(), client.t("OPER failed; check the server logs for details."))
 
 		// hopefully not too spammy given the throttling:
+		ip := rb.session.IP().String()
 		if oper == nil {
-			server.logger.Info("opers", "OPER failed with invalid oper name", msg.Params[0])
+			server.logger.Info("opers", "OPER failed with invalid oper name", msg.Params[0], "from IP", ip)
 		} else if certFailed {
-			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid certfp")
+			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid certfp", "from IP", ip)
 		} else if passwordFailed {
-			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid password")
+			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid password", "from IP", ip)
 		} else {
 			// should not be possible given config validation
-			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid config")
+			server.logger.Info("opers", "OPER attempt for", msg.Params[0], "failed with invalid config", "from IP", ip)
 		}
 
 		return false

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -876,6 +876,7 @@ func nsIdentifyHandler(service *ircService, server *Server, client *Client, comm
 	if loginSuccessful {
 		sendSuccessfulAccountAuth(service, client, rb, true)
 	} else if !nickFixupFailed {
+		server.logger.Info("accounts", rb.session.ConnID(), "failed IDENTIFY as", username, "from IP", rb.session.IP().String())
 		service.Notice(rb, fmt.Sprintf(client.t("Authentication failed: %s"), authErrorToMessage(server, err)))
 	}
 }

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -876,7 +876,8 @@ func nsIdentifyHandler(service *ircService, server *Server, client *Client, comm
 	if loginSuccessful {
 		sendSuccessfulAccountAuth(service, client, rb, true)
 	} else if !nickFixupFailed {
-		server.logger.Info("accounts", rb.session.ConnID(), "failed IDENTIFY as", username, "from IP", rb.session.IP().String())
+		server.logger.Info("accounts", rb.session.ConnID(), "failed IDENTIFY as", username)
+		server.logger.Info("connect-ip", rb.session.ConnID(), "failed IDENTIFY as", username, "from", rb.session.IP().String())
 		service.Notice(rb, fmt.Sprintf(client.t("Authentication failed: %s"), authErrorToMessage(server, err)))
 	}
 }


### PR DESCRIPTION
## Summary

None of the three authentication-failure paths logged anything usable by external tools like fail2ban:

- Failed `OPER` attempts *were* logged (category `opers`), but without any IP or session identifier on the line — a log-watching tool has no way to know who to act on.
- Failed SASL authentication (PLAIN, IRCv3 bearer token, and any future mechanism routed through `sendAuthErrorResponse`) logged nothing server-side at all — only a client-facing numeric reply.
- Failed NickServ `IDENTIFY` likewise logged nothing server-side.

This adds `"from IP", <address>` (OPER) or a session ID + IP (SASL/IDENTIFY, matching the existing successful-login log format in `sendSuccessfulAccountAuth`/`handlers.go:148`) to each. No behavior change from the client's perspective — this only adds server-side log detail.

Ran into this concretely trying to set up fail2ban for a small community server: with stock logging there was nothing to filter on for two of the three failure types, and the third had no IP to ban.

## Test plan
- [x] `go build`, `go vet ./irc/...`, `gofmt -l` clean
- [x] `go test ./irc/...` passes
- [x] Deployed to a live production server (patched build of `v2.19.0`) and verified end-to-end: triggered real failed OPER/SASL/IDENTIFY attempts, confirmed each produces a single log line with the correct source IP, wired up a fail2ban jail against it, triggered an actual ban (6th failed OPER attempt got refused at the network level), and confirmed unban restores access