### PR TITLE
unpin docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## build ergo binary
-FROM docker.io/golang:1.27-alpine3.22 AS build-env
+FROM docker.io/golang:1.27-alpine AS build-env
 
 RUN apk upgrade -U --force-refresh --no-cache && apk add --no-cache --purge --clean-protected -l -u make git
 
@@ -16,7 +16,7 @@ RUN sed -i 's/^\(\s*\)\"127.0.0.1:6667\":.*$/\1":6667":/' /go/src/github.com/erg
 RUN make install
 
 ## build ergo container
-FROM docker.io/alpine:3.22
+FROM docker.io/alpine:3.22.5
 
 # metadata
 LABEL maintainer="Daniel Oaks <daniel@danieloaks.net>,Daniel Thamdrup <dallemon@protonmail.com>" \


### PR DESCRIPTION
We pinned the build image to 3.22 in #2306 to work around a bug in 3.23. The bug is resolved now, so we can unpin the build image while keeping the production image at 3.22 until the EOL next year.